### PR TITLE
feat: IsOpenOption + FileExplorer.SelectedSignal

### DIFF
--- a/src/SutilOxide/Dock.fs
+++ b/src/SutilOxide/Dock.fs
@@ -233,7 +233,7 @@ let private _update (options : unit -> Options) (unmount : string -> unit) msg (
         {
             model with
                 Docks = { Stations = model.Docks.Stations.Add( pane.Location, station' ) }
-        } , Cmd.batch [ if pane.IsOpen then Cmd.ofMsg (ShowPane pane.Key) else Cmd.none; cmdMonitorAll ]
+        } , Cmd.batch [ if pane.IsOpenCalculated then Cmd.ofMsg (ShowPane pane.Key) else Cmd.none; cmdMonitorAll ]
 
     // | SelectPane (loc,pane) ->
     //     let currentPane = model.SelectedPanes[loc]
@@ -882,7 +882,7 @@ with
         model.Value.SelectedPanes.Values |> Seq.toArray |> Array.choose id
 
     member __.AddPane (key : string, label : string, initLoc : DockLocation, header : SutilElement, content : SutilElement, show : bool ) =
-        __.AddPane { DockPane.Default(key) with Label = LabelString label; Location = initLoc; Header = header; Content = content; IsOpen = show}
+        __.AddPane { DockPane.Default(key) with Label = LabelString label; Location = initLoc; Header = header; Content = content; IsOpen = IsOpenOption.Default show}
 
     member __.AddPane (key, options : PaneOptions list) =
         __.AddPane( DockPane.Create(key, options ))

--- a/src/SutilOxide/FileExplorer.fs
+++ b/src/SutilOxide/FileExplorer.fs
@@ -476,6 +476,7 @@ type FileExplorer( fs : IFsAsync ) =
 
     let mutable onEdit : string -> unit = ignore
     let mutable onDrop : FileList -> IFsAsync -> string -> bool = fun _ _ _ -> false
+    let selection = SutilOxide.Reactive.Cell.make ""
 
     let create fs =
         //let sessionState = loadSessionState() |> Option.defaultWith defaultSessionState
@@ -498,6 +499,8 @@ type FileExplorer( fs : IFsAsync ) =
         member _.OnDrop( h : FileList -> IFsAsync -> string -> bool ) = onDrop <- h
         member _.Dispatch = dispatch
         member _.Selected = model.Value.Selected
+        member _.SelectedSignal = model .> _.Selected |> SutilOxide.Reactive.Signal.fromObservable ""
+        
         member _.CurrentFolder = model.Value.Cwd
 
         member __.SelectPath( path : string ) =

--- a/src/SutilOxide/Types.fs
+++ b/src/SutilOxide/Types.fs
@@ -158,6 +158,11 @@ type LabelElement =
     | LabelString of string
     | LabelElement of SutilElement
 
+[<RequireQualifiedAccess>]
+type IsOpenOption = 
+    | Definite of bool
+    | Default of bool
+
 type PaneOptions =
     | Group of string
     | Label of string
@@ -173,7 +178,7 @@ type PaneOptions =
     | Location of DockLocation
     | Header of SutilElement
     | Content of SutilElement
-    | IsOpen of bool
+    | IsOpen of IsOpenOption
     | IsExclusive of bool
     | IsMinimized of bool
     | OnClose of (unit -> unit)
@@ -230,13 +235,14 @@ type DockPane =
         HeaderTooltip : string option
         Content : SutilElement
         IsExclusive : bool
-        IsOpen : bool
+        IsOpen : IsOpenOption
         IsMinimized : bool
         OnClose : unit -> unit
         OnMinimize : unit -> unit
         OnShow : bool -> unit
         OnChildActivate : string -> bool -> unit
     }
+    member __.IsOpenCalculated = __.IsOpen = IsOpenOption.Default true || __.IsOpen = IsOpenOption.Definite true
     member __.Key = __.StrictKey.ToString()
     member __.KeyAsClass = __.StrictKey.ToString()
     member __.KeyAsLabel = __.StrictKey.AsLabel
@@ -261,7 +267,7 @@ type DockPane =
             Header = text key
             HeaderTooltip = None
             Content = Html.div key
-            IsOpen = false
+            IsOpen = IsOpenOption.Default false
             IsExclusive = false
             IsMinimized = false
             OnClose = ignore


### PR DESCRIPTION
## Summary

Two commits supporting fsimgo's Projects Explorer work (davedawkins/fsimgo#224).

- **feat: IsOpenOption.Default | Definite for pane visibility** — replaces `IsOpen of bool` with a tagged option that distinguishes "use stored visibility if known, else fall back to v" (`Default v`) from "force this state, ignore stored visibility" (`Definite v`). `AddPane(key, label, …, show : bool)` legacy overload wraps to `Default show`. New `DockPane.IsOpenCalculated` resolves to `bool` for internal consumers.
- **feat: FileExplorer.SelectedSignal observable selection** — exposes the existing selected-path as an ISignal so callers can bind to it without polling.

## Test plan

- [ ] Build clean (`dotnet build src/SutilOxide`).
- [ ] fsimgo's `npm run dev` compiles against this branch (consumes IsOpenOption + IsOpenCalculated + SelectedSignal).
- [ ] Existing call-sites that pass `show : bool` to `AddPane(key, label, …)` still behave the same — `Default show` semantics match the prior unconditional bool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)