### PR TITLE
Detect and repair multi-parent reference corruption

### DIFF
--- a/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
+++ b/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
@@ -820,6 +820,30 @@ export class KeyedStorageIndexedDB {
 
             errors.push(...orphanedUids);
 
+            // Multi-parent detection: every non-root UID must appear in
+            // exactly one parent's Children list. Multiple in-edges mean
+            // path lookups can fail when the entry's own Name disagrees
+            // with a parent's Children-row label.
+            const inEdges = new Map();
+            for (const [parentUid, entry] of uidToEntry) {
+                for (const row of entry.Children) {
+                    if (Array.isArray(row) && row.length >= 2 && typeof row[1] === 'number') {
+                        const childUid = row[1];
+                        if (!inEdges.has(childUid)) inEdges.set(childUid, []);
+                        inEdges.get(childUid).push({ parentUid, name: row[0] });
+                    }
+                }
+            }
+            for (const [childUid, refs] of inEdges) {
+                if (refs.length < 2) continue;
+                const child = uidToEntry.get(childUid);
+                const childName = child ? child.Name : '?';
+                const refSummary = refs.map(r => `uid:${r.parentUid}/"${r.name}"`).join(', ');
+                errors.push(
+                    `Entry uid:${childUid} ("${childName}") has ${refs.length} parent references ` +
+                    `(should be 1): ${refSummary}`);
+            }
+
             // (root) bookkeeping sanity: NextUid must exceed every existing
             // uid, otherwise the next allocation will collide. Warn-only;
             // the FS continues to function with a stale NextUid (just risks
@@ -1052,17 +1076,53 @@ export class KeyedStorageIndexedDB {
 
             const validUids = new Set(uidToEntry.keys());
 
+            // Multi-parent detection: build inverse map and pick a canonical
+            // keeper for each UID with >1 in-edges. Heuristic: keep the row
+            // whose name matches the child's own Name field (the canonical
+            // reference). If ambiguous (none match, or multiple match),
+            // pick the lowest-UID parent deterministically — the entry
+            // stays reachable either way; the duplicate rows are removed
+            // by the same per-parent filter that handles dangling refs.
+            const parentsOf = new Map();
+            for (const [parentUid, entry] of uidToEntry) {
+                for (const row of entry.Children) {
+                    if (Array.isArray(row) && row.length >= 2 && typeof row[1] === 'number') {
+                        const childUid = row[1];
+                        if (!parentsOf.has(childUid)) parentsOf.set(childUid, []);
+                        parentsOf.get(childUid).push({ parentUid, name: row[0] });
+                    }
+                }
+            }
+            const keeperOf = new Map();   // childUid -> {parentUid, name} (only when refs > 1)
+            for (const [childUid, refs] of parentsOf) {
+                if (refs.length < 2) continue;
+                const child = uidToEntry.get(childUid);
+                if (!child) continue;
+                const matching = refs.filter(r => r.name === child.Name);
+                const pool = matching.length >= 1 ? matching : refs;
+                keeperOf.set(childUid, pool.slice().sort((a, b) => a.parentUid - b.parentUid)[0]);
+            }
+
+            // Per-parent filter: drops malformed rows, dangling refs, and
+            // duplicate-parent rows (keeper retained; others removed).
             for (const [uid, entry] of uidToEntry) {
                 if (!entry.Children.length) continue;
                 const before = entry.Children;
-                const after = before.filter(child => {
-                    if (!Array.isArray(child) || child.length < 2) {
-                        console.log(`Removing malformed child row from uid:${uid}: ${JSON.stringify(child)}`);
+                const after = before.filter(row => {
+                    if (!Array.isArray(row) || row.length < 2) {
+                        console.log(`Removing malformed child row from uid:${uid}: ${JSON.stringify(row)}`);
                         return false;
                     }
-                    const childUid = child[1];
+                    const [name, childUid] = row;
                     if (!validUids.has(childUid)) {
-                        console.log(`Removing dangling reference: uid:${uid}/${child[0]} -> uid:${childUid}`);
+                        console.log(`Removing dangling reference: uid:${uid}/${name} -> uid:${childUid}`);
+                        return false;
+                    }
+                    const keeper = keeperOf.get(childUid);
+                    if (keeper && !(keeper.parentUid === uid && keeper.name === name)) {
+                        console.log(
+                            `Removing duplicate parent ref: uid:${uid}/"${name}" -> uid:${childUid} ` +
+                            `(keeper: uid:${keeper.parentUid}/"${keeper.name}")`);
                         return false;
                     }
                     return true;
@@ -1074,6 +1134,8 @@ export class KeyedStorageIndexedDB {
                     this._setMetaModified(updated);
                     const bytes = this._encodeEntryBytes(updated, uidToOrig.get(uid));
                     await this.put(uidToKey.get(uid), bytes);
+                    uidToEntry.set(uid, updated);
+                    uidToOrig.set(uid, bytes);
                 }
             }
 


### PR DESCRIPTION
## Summary

Detect and repair multi-parent reference corruption — a UID referenced from more than one parent's Children list.

## The corruption shape (seen in the wild)

A non-root UID must appear in exactly one parent's Children list. Multi-parent corruption breaks path lookups because the entry's *displayed* name comes from its own `Name` field, while a parent's reference row carries a potentially different name. Paths built from the displayed name fail to resolve through the non-matching parent.

Concrete example seen in `fsim-user-davidd`:
- `uid:41500` has `Name: "9b7a17b58c623729bf21bfb0ab86015def12ee"` (a hash, content-addressed).
- It's referenced from its sha-shard folder under that hash (the canonical name).
- It's *also* referenced from `packagesCorrupted` under the name `"CorePackage"`.
- `ls -l packagesCorrupted` shows the file under the hash (it reads the child's own `Name`).
- Project status lookup builds path `packagesCorrupted/9b7a17b...` → fails to resolve (the parent's Children-row label is `"CorePackage"`, not the hash) → `Failed to read contents`.
- Removal fails for the same reason.

The prior `checkConsistency` tolerated this: reachability is satisfied (the entry is reachable via either parent), no UID dangles, all crosrefs valid. The check assumed the FS is a tree. It isn't, here — it's a DAG with one node having two in-edges.

## Changes

1. **`checkConsistency`** — new detection block: build the inverse `childUid → [{parentUid, name}]` map; for every UID with multiple in-edges, emit an error naming the conflicting parents and their row labels.
2. **`fixDanglingReferences`** — extended the same per-parent filter that drops dangling/malformed rows to also drop duplicate parent rows. Keeper heuristic:
   - Exactly one parent's Children-row name matches the child's own `Name` → that's the keeper.
   - Zero or multiple match → lowest-UID parent (deterministic).
   - The entry stays reachable either way; the duplicate rows are removed.
3. Idempotent: re-running on a clean store returns 0 and writes nothing. Preserves Uint8Array storage, blob tails, and Meta-array timestamps. Same contracts as the prior #294 work.

## Test plan

Tests in the companion fsimgo PR. Red-first verified via stash-and-rerun on this branch:
- Pre-fix sutil-oxide → **5 fail / 21 pass** (the 5 new multi-parent-related tests).
- Post-fix → **26 / 26 pass**.

Full TS suite: **644 / 644**. F# Mocha: **166 / 166**.

## Companion PR

[davedawkins/fsimgo](https://github.com/davedawkins/fsimgo/pulls) — 9 new vitest cases. Merge order: this PR first, then the test PR (the tests import from the post-fix sutil-oxide).

## Effect on the user's broken DB

For their `uid:41500`:
- `child.Name = "9b7a17b58c623729bf21bfb0ab86015def12ee"` (the hash).
- Matching parents: `[{uid:40712, name: "9b7a17b..."}]` (exactly one).
- Keeper: `uid:40712`.
- `["CorePackage", 41500]` row dropped from `uid:4447` (`packagesCorrupted`).

After repair: `packagesCorrupted` no longer references the hash file; the hash file remains correctly reachable via its sha-shard parent under its canonical name. Project status lookup stops failing.
