### PR TITLE
Prefer reachable parents in multi-parent keeper-pick (redteam follow-up to #6)

### DIFF
--- a/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
+++ b/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
@@ -1093,13 +1093,47 @@ export class KeyedStorageIndexedDB {
                     }
                 }
             }
+            // Reachability from root via the (current, pre-repair) Children
+            // edges. The keeper-pick prefers reachable parents over
+            // orphan-subtree parents — a keeper inside an orphan subtree
+            // would silently orphan the child, fresh corruption.
+            const reachable = new Set();
+            (() => {
+                const stack = [0];
+                while (stack.length > 0) {
+                    const u = stack.pop();
+                    if (reachable.has(u)) continue;
+                    reachable.add(u);
+                    const e = uidToEntry.get(u);
+                    if (e && Array.isArray(e.Children)) {
+                        for (const row of e.Children) {
+                            if (Array.isArray(row) && row.length >= 2 && typeof row[1] === 'number') {
+                                if (uidToEntry.has(row[1])) stack.push(row[1]);
+                            }
+                        }
+                    }
+                }
+            })();
+
+            // Keeper-pick priority:
+            //  1. Reachable parent whose row name matches child.Name (canonical + reachable).
+            //  2. Reachable parent (any name; lowest-UID deterministic).
+            //  3. Any parent whose row name matches child.Name (canonical, even if orphaned).
+            //  4. Any parent (lowest-UID deterministic).
+            // If the keeper falls into class 3 or 4, the child remains in an
+            // orphan subtree post-repair — fixOrphanedEntries will pick it up.
             const keeperOf = new Map();   // childUid -> {parentUid, name} (only when refs > 1)
             for (const [childUid, refs] of parentsOf) {
                 if (refs.length < 2) continue;
                 const child = uidToEntry.get(childUid);
                 if (!child) continue;
-                const matching = refs.filter(r => r.name === child.Name);
-                const pool = matching.length >= 1 ? matching : refs;
+                const pools = [
+                    refs.filter(r => reachable.has(r.parentUid) && r.name === child.Name),
+                    refs.filter(r => reachable.has(r.parentUid)),
+                    refs.filter(r => r.name === child.Name),
+                    refs,
+                ];
+                const pool = pools.find(p => p.length >= 1) || refs;
                 keeperOf.set(childUid, pool.slice().sort((a, b) => a.parentUid - b.parentUid)[0]);
             }
 


### PR DESCRIPTION
Follow-up to davedawkins/sutil-oxide#6 (merged). A /redteam pass found that the lowest-UID tiebreaker is reachability-blind: a multi-parent UID with one orphan-subtree parent (lower UID) and one reachable parent (higher UID) would silently land the child in the orphan subtree, and `checkConsistency` would still report `isValid: true` post-repair.

New keeper-pick priority:
1. Reachable parent + canonical-name match.
2. Reachable parent (any name; lowest-UID).
3. Canonical-name parent (possibly orphaned).
4. Any parent (lowest-UID).

If priority 3 or 4 wins, the child stays in an orphan subtree and `fixOrphanedEntries` will pick it up.

Companion fsimgo PR with the 4 new tests. The headline test is the red-first poison case the redteam found (fails against the pre-fix code, passes after).