### PR TITLE
feat: add live SubscriberCount to reactive primitives (fsimgo #394)

### DIFF
--- a/src/SutilOxide/Reactive.fs
+++ b/src/SutilOxide/Reactive.fs
@@ -33,8 +33,14 @@ module Internal =
     open System.Collections.Generic
     open Fable.Core
 
+    /// Non-generic base exposing live subscriber count for leak instrumentation (#394).
+    [<AbstractClass>]
+    type SubscriberCounted() =
+        abstract SubscriberCount : int
+
     [<Mangle>]
     type EventSourceWithResult<'T,'R>() =
+        inherit SubscriberCounted()
         let mutable nextId = 0
         let clients = Dictionary<int, 'T -> 'R>()
 
@@ -62,6 +68,8 @@ module Internal =
 
         member _.Dispose() = clients.Clear()
 
+        override _.SubscriberCount = clients.Count
+
         member this.NotifyAndCollect(value : 'T) : 'R[] =
             [|
                 for client in clients.Values do
@@ -80,6 +88,7 @@ module Internal =
             member this.Notify(v) = this.Notify(v)
 
     type Cell<'T>(init: (unit -> 'T) option) =
+        inherit SubscriberCounted()
         let disposeListeners = new ResizeArray<unit -> unit>()
         let clients = new EventSourceWithResult<'T,unit>()
         
@@ -114,6 +123,8 @@ module Internal =
 
         member _.Set(v) = _set_notify v
         member _.Value with get() = _get(true)
+
+        override _.SubscriberCount = clients.SubscriberCount
 
         member _.OnDispose( f : unit -> unit ) =
             disposeListeners.Add(f)


### PR DESCRIPTION
## Add `SubscriberCount` to reactive primitives (for fsimgo #394 leak instrumentation)

Adds a read-only live subscriber count to `SutilOxide.Reactive` so downstream code can detect subscription leaks (a store/observable that is subscribed without releasing the `IDisposable`).

### Change
- New non-generic abstract base `Internal.SubscriberCounted` with `abstract SubscriberCount : int`.
- `Internal.EventSourceWithResult` and `Internal.Cell` inherit it and report `clients.Count`.
- Because `EventSource` derives from `EventSourceWithResult` and `Cell` is the backing of `Cell.make`/`EventSource.make`, every `IEventSource`/`ISignal`/`ICell` produced by the factories carries a live subscriber count.

A **non-generic base class** is used deliberately: Fable erases interfaces at runtime, so an `:? IInterface` type-test always evaluates false (and emits `warning FABLE: Cannot type test`). A concrete class type-test works, so consumers read the count via:
```fsharp
match box store with
| :? SutilOxide.Reactive.Internal.SubscriberCounted as s -> s.SubscriberCount
| _ -> -1
```

### Why
fsimgo #394 fixes a batch of subscription/observer leaks and needs an instrumented, automated check that re-mounting a pane (or reopening an editor) returns the backing global store's subscriber count to baseline. The count is read-only and additive — no behaviour change to existing reactive code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
