### PR TITLE
fix: byte-budget LRU entry/kv caches + diagnostics

### DIFF
--- a/src/SutilOxide/FileSystem/EntryCache.fs
+++ b/src/SutilOxide/FileSystem/EntryCache.fs
@@ -1,0 +1,111 @@
+/// #542: byte-budgeted LRU cache of int -> 'v, with a per-entry size ceiling. Overflow evicts the
+/// least-recently-used entry one at a time; there is no code path that empties the cache wholesale.
+/// Used by KeyedStorageFileSystemAsync as the Layer-1 in-memory entry cache.
+module SutilOxide.FileSystem.EntryCache
+
+open System.Collections.Generic
+
+// Recency order lives in a plain ResizeArray (index 0 = least-recently-used, last = most-recently-
+// used) rather than a System.Collections.Generic.LinkedList<'T> -- Fable does not support LinkedList.
+// Touch/remove are O(n) (IndexOf + RemoveAt), acceptable at the entry counts a byte budget bounds
+// this to in practice (thousands, not millions).
+type LruByteCache<'v>(sizeOf: 'v -> int, initialBudgetBytes: int, entryCeilingBytes: int) =
+    let store = Dictionary<int, 'v>()
+    let sizes = Dictionary<int, int>()
+    let order = ResizeArray<int>()
+    let mutable totalBytes = 0
+    let mutable budgetBytes = initialBudgetBytes
+
+    let mutable hits = 0
+    let mutable misses = 0
+    let mutable evictions = 0
+    let mutable admissionRefused = 0
+    let mutable highWaterEntries = 0
+    let mutable highWaterBytes = 0
+
+    let touch (uid: int) =
+        let idx = order.IndexOf uid
+        if idx >= 0 then
+            order.RemoveAt idx
+            order.Add uid
+
+    let removeInternal (uid: int) =
+        match store.TryGetValue uid with
+        | true, _ ->
+            totalBytes <- totalBytes - sizes.[uid]
+            store.Remove uid |> ignore
+            sizes.Remove uid |> ignore
+            let idx = order.IndexOf uid
+            if idx >= 0 then order.RemoveAt idx
+        | false, _ -> ()
+
+    let evictOneLru () =
+        if order.Count > 0 then
+            let uid = order.[0]
+            removeInternal uid
+            evictions <- evictions + 1
+
+    let bumpHighWater () =
+        highWaterEntries <- max highWaterEntries store.Count
+        highWaterBytes <- max highWaterBytes totalBytes
+
+    let evictWhileOverBudget () =
+        // The `store.Count > 1` guard is what makes "never empties itself wholesale" structural:
+        // eviction always leaves at least the most-recently-inserted/touched entry resident.
+        while totalBytes > budgetBytes && store.Count > 1 do
+            evictOneLru ()
+
+    member _.Count = store.Count
+    member _.Bytes = totalBytes
+    member _.Budget = budgetBytes
+    member _.EntryCeiling = entryCeilingBytes
+
+    member _.ContainsKey(uid: int) : bool = store.ContainsKey uid
+
+    member _.TryGet(uid: int) : 'v option =
+        match store.TryGetValue uid with
+        | true, v ->
+            hits <- hits + 1
+            touch uid
+            Some v
+        | false, _ ->
+            misses <- misses + 1
+            None
+
+    /// Insert/replace. An entry above the per-entry ceiling is never admitted (refused, not
+    /// evicted-immediately-after) -- this is what keeps one oversized entry (e.g. project.json)
+    /// from displacing the rest of the working set.
+    member this.Put(uid: int, v: 'v) =
+        let size = sizeOf v
+        if size > entryCeilingBytes then
+            admissionRefused <- admissionRefused + 1
+            removeInternal uid
+        else
+            removeInternal uid
+            store.[uid] <- v
+            sizes.[uid] <- size
+            totalBytes <- totalBytes + size
+            order.Add uid
+            evictWhileOverBudget ()
+        bumpHighWater ()
+
+    /// Unconditional -- never gated by the eviction guard in Put. Remove is a caller-directed
+    /// delete (the entry is actually gone from the backing store), not an eviction-under-pressure
+    /// decision, so it must succeed even when this is the last cached entry (#542 red-team finding).
+    member _.Remove(uid: int) = removeInternal uid
+
+    member _.SetBudget(bytes: int) =
+        budgetBytes <- bytes
+        evictWhileOverBudget ()
+
+    member _.Stats() : LayerStats =
+        { Hits = hits; Misses = misses; Evictions = evictions; Flushes = 0
+          AdmissionRefused = admissionRefused; Entries = store.Count; Bytes = totalBytes
+          HighWaterEntries = highWaterEntries; HighWaterBytes = highWaterBytes
+          BudgetBytes = budgetBytes; EntryCeilingBytes = entryCeilingBytes; Enabled = true
+          TransactionsOpened = 0; ReadsIssued = misses }
+
+    /// Zero the counters. Never touches cached entries -- see `project fs-stats reset`.
+    member _.ResetCounters() =
+        hits <- 0; misses <- 0; evictions <- 0; admissionRefused <- 0
+        highWaterEntries <- store.Count; highWaterBytes <- totalBytes

--- a/src/SutilOxide/FileSystem/EntryCacheDiagnostics.fs
+++ b/src/SutilOxide/FileSystem/EntryCacheDiagnostics.fs
@@ -1,0 +1,49 @@
+/// #542: global registry for the active session's two storage-cache layers (Layer 1 = the F#
+/// in-memory entry cache in KeyedStorageFileSystemAsync, Layer 2 = the JS IndexedDB key/value
+/// cache in KeyedStorageIndexedDB), read by the fsimgo app's `project fs-stats` command.
+///
+/// Explicit registration, not "last constructed wins": a second KeyedStorageFileSystemAsync /
+/// KeyedStorageIndexedDB pair (fsimgo's client/src/App/TestUI.fs) is constructed unconditionally
+/// in every real session too. Relying on construction order to decide which instance is "active"
+/// would silently report the wrong instance's numbers if that ordering ever changed. Instead the
+/// one call site that knows it owns the real session storage (fsimgo's Server.fs) calls `setActive`
+/// explicitly after construction.
+module SutilOxide.EntryCacheDiagnostics
+
+open SutilOxide.FileSystem
+
+let mutable private activeEntryCache : IEntryCacheDiagnostics option = None
+let mutable private activeKvStore : IKeyedStorageAsync option = None
+
+let setActive (entryCache: IEntryCacheDiagnostics) (kvStore: IKeyedStorageAsync) =
+    activeEntryCache <- Some entryCache
+    activeKvStore <- Some kvStore
+
+let entryCacheStats () = activeEntryCache |> Option.map (fun d -> d.GetStats())
+let kvStoreStats () = activeKvStore |> Option.map (fun kv -> kv.GetStats())
+
+let reset () =
+    activeEntryCache |> Option.iter (fun d -> d.ResetStats())
+    activeKvStore |> Option.iter (fun kv -> kv.ResetStats())
+
+let setTracingEnabled (enabled: bool) =
+    activeEntryCache |> Option.iter (fun d -> d.SetTracingEnabled enabled)
+    activeKvStore |> Option.iter (fun kv -> kv.SetTracingEnabled enabled)
+
+let setBudget (layer: string) (bytes: int) : Result<unit, string> =
+    match layer with
+    | "entry" ->
+        match activeEntryCache with
+        | Some d -> d.SetCacheBudget bytes; Ok ()
+        | None -> Error "entry cache is not active"
+    | "kv" ->
+        match activeKvStore with
+        | Some kv -> kv.SetCacheBudget bytes; Ok ()
+        | None -> Error "kv store is not active"
+    | other -> Error (sprintf "unknown layer '%s' (expected 'entry' or 'kv')" other)
+
+let entryCacheTopReads (n: int) =
+    activeEntryCache |> Option.map (fun d -> d.GetTopReads n) |> Option.defaultValue [||]
+
+let kvStoreTopReads (n: int) =
+    activeKvStore |> Option.map (fun kv -> kv.GetTopReads n) |> Option.defaultValue [||]

--- a/src/SutilOxide/FileSystem/FileSystem.fs
+++ b/src/SutilOxide/FileSystem/FileSystem.fs
@@ -244,6 +244,39 @@ module Internal =
 
 open JsHelpers
 
+/// Counters + live configuration for one cache layer (#542). Shared shape for both the F#
+/// in-memory entry cache (Layer 1, KeyedStorageFileSystemAsync) and the JS IndexedDB key/value
+/// cache (Layer 2, KeyedStorageIndexedDB) so `project fs-stats` can report them side by side.
+/// Layer 1 has no IndexedDB transactions of its own, so TransactionsOpened/ReadsIssued read 0 there.
+type LayerStats =
+    { Hits: int
+      Misses: int
+      Evictions: int
+      Flushes: int
+      AdmissionRefused: int
+      Entries: int
+      Bytes: int
+      HighWaterEntries: int
+      HighWaterBytes: int
+      BudgetBytes: int
+      EntryCeilingBytes: int
+      Enabled: bool
+      TransactionsOpened: int
+      ReadsIssued: int }
+
+type ITopReadsEntry =
+    abstract Key: string
+    abstract Count: int
+
+/// Implemented by a cache layer so `EntryCacheDiagnostics`'s global registry can report and
+/// control it without depending on the concrete type. #542
+type IEntryCacheDiagnostics =
+    abstract GetStats: unit -> LayerStats
+    abstract ResetStats: unit -> unit
+    abstract SetCacheBudget: int -> unit
+    abstract SetTracingEnabled: bool -> unit
+    abstract GetTopReads: int -> ITopReadsEntry[]
+
 type IKeyedStorageAsync =
     abstract Exists: string -> Promise<bool>
     abstract Get: string -> Promise<obj>
@@ -257,6 +290,11 @@ type IKeyedStorageAsync =
     abstract LogConsistencyCheck: unit -> Promise<bool>
     abstract FixDanglingReferences: unit -> Promise<int>
     abstract FixOrphanedEntries: unit -> Promise<int>
+    abstract GetStats: unit -> LayerStats
+    abstract ResetStats: unit -> unit
+    abstract SetCacheBudget: int -> unit
+    abstract SetTracingEnabled: bool -> unit
+    abstract GetTopReads: int -> ITopReadsEntry[]
 
 module private BrowserStorage =
     let mk rootKey key = sprintf "%s/%s" rootKey key

--- a/src/SutilOxide/FileSystem/KeyedStorageFileSystemAsync.fs
+++ b/src/SutilOxide/FileSystem/KeyedStorageFileSystemAsync.fs
@@ -18,21 +18,32 @@ type KeyedStorageFileSystemAsync( keyStorage : IKeyedStorageAsync ) =
     let mutable root = { NextUid = 1 }
     let mutable onChange : (FileSystemEvent -> unit) list = []
     
-    // Add a cache for frequently accessed entries
-    let entryCache = System.Collections.Generic.Dictionary<int, EntryStorage option>()
-    let [<Literal>]  CacheLimit = 100
+    // #542: byte-budgeted LRU entry cache (Layer 1). 8 MB comfortably covers a real project's
+    // source-file working set (measured ~416 KB for ContactLens's 223 files) with headroom for a
+    // session touching several projects; 512 KB per-entry ceiling excludes project.json-class
+    // oversized entries automatically, without naming them. Both are runtime-settable via
+    // `project fs-stats set entry <bytes>`.
+    let [<Literal>] DefaultBudgetBytes = 8388608
+    let [<Literal>] DefaultEntryCeilingBytes = 524288
+    let entrySizeOf (v: EntryStorage option) = match v with Some e -> e.Meta.Size | None -> 0
+    let entryCache = SutilOxide.FileSystem.EntryCache.LruByteCache<EntryStorage option>(entrySizeOf, DefaultBudgetBytes, DefaultEntryCeilingBytes)
     let [<Literal>]  RootKeyName = "(root)"
     let [<Literal>]  RootName = "/"
     let [<Literal>]  RootUid : Uid = 0
 
+    // #542: per-key read histogram for `project fs-stats top` -- unbounded, so it only accumulates
+    // while tracing is enabled (the same flag `project compile-trace on/off` already toggles).
+    let mutable tracingEnabled = false
+    let topReads = System.Collections.Generic.Dictionary<int, int>()
+
+    let bumpTopRead (uid: int) =
+        if tracingEnabled then
+            let cur = match topReads.TryGetValue uid with | true, v -> v | _ -> 0
+            topReads.[uid] <- cur + 1
+
     let uidKey uid = sprintf "uid:%d" uid
 
     let notifyOnChange (ev ) = onChange |> List.iter (fun h -> h ev)
-
-    // Function to clear cache when it gets too large
-    let trimCache() =
-        if entryCache.Count > CacheLimit then
-            entryCache.Clear()
 
     let beginBatch() =
         keyStorage.BeginBatch()
@@ -44,8 +55,7 @@ type KeyedStorageFileSystemAsync( keyStorage : IKeyedStorageAsync ) =
     // Initialization
 
     let putEntryUnsafe (e : EntryStorage) =
-        entryCache.[e.Uid] <- Some e
-        trimCache()
+        entryCache.Put(e.Uid, Some e)
         keyStorage.Put( uidKey e.Uid, fileEntryToByteArray e)
 
     let putRoot() =
@@ -133,7 +143,7 @@ type KeyedStorageFileSystemAsync( keyStorage : IKeyedStorageAsync ) =
     let delEntry (e : EntryStorage) =
         promise {
             do! init()
-            entryCache.Remove(e.Uid) |> ignore
+            entryCache.Remove(e.Uid)
             do! keyStorage.Remove (uidKey e.Uid)
         }
 
@@ -143,47 +153,33 @@ type KeyedStorageFileSystemAsync( keyStorage : IKeyedStorageAsync ) =
             do! putEntryUnsafe e
         }
 
-    let getEntry (uid : Uid) : PromiseResult<EntryStorage,string> = 
+    let getEntry (uid : Uid) : PromiseResult<EntryStorage,string> =
+        bumpTopRead uid
         // Check cache first
-        if entryCache.ContainsKey(uid) then
-            entryCache.[uid] |> (function Some x -> Ok x | None -> Error "Missing") |> Promise.lift
-        else
+        match entryCache.TryGet(uid) with
+        | Some cached ->
+            cached |> (function Some x -> Ok x | None -> Error "Missing") |> Promise.lift
+        | None ->
             promise {
                 do! init()
 
                 let! entry = getDecodedEntry (uidKey uid) // keyStorage.Get (uidKey uid)
 
-                // if entry = null then
-                //     return (Error ("Not entry for UID: " + string uid))
-                // else
-                //     match fileEntryFromJSON entry with
-                //     | Ok r -> 
-                //         // Cache the result
-                //         entryCache.[uid] <- Some r
-                //         trimCache()
-                //         return Ok r
-                //     | Error msg ->
-                //         entryCache.[uid] <- None
-                //         return Error msg
-
-
                 match entry with
-                | Ok r -> 
-                    // Cache the result
-                    entryCache.[uid] <- Some r
-                    trimCache()
+                | Ok r ->
+                    entryCache.Put(uid, Some r)
                     return Ok r
                 | Error msg ->
-                    entryCache.[uid] <- None
+                    entryCache.Put(uid, None)
                     return Error msg
 
             }
 
     let entryExists uid =
         promise {
-            if entryCache.ContainsKey(uid) then
-                return entryCache.[uid].IsSome
-            else
+            match entryCache.TryGet(uid) with
+            | Some cached -> return cached.IsSome
+            | None ->
                 do! init()
                 return! keyStorage.Exists (uidKey uid)
         }
@@ -691,6 +687,34 @@ type KeyedStorageFileSystemAsync( keyStorage : IKeyedStorageAsync ) =
 
 with
     member this.Initialise() = initRoot()
+
+    // #542: Layer-1 (in-memory entry cache) diagnostics -- see IEntryCacheDiagnostics.
+    member this.GetCacheStats() : LayerStats = entryCache.Stats()
+
+    member this.ResetCacheStats() = entryCache.ResetCounters()
+
+    member this.SetCacheBudget(bytes: int) = entryCache.SetBudget(bytes)
+
+    member this.SetTracingEnabled(enabled: bool) =
+        tracingEnabled <- enabled
+        if not enabled then topReads.Clear()
+
+    member this.GetTopReadsList(n: int) : ITopReadsEntry[] =
+        topReads
+        |> Seq.sortByDescending (fun kv -> kv.Value)
+        |> Seq.truncate (max 0 n)
+        |> Seq.map (fun kv ->
+            { new ITopReadsEntry with
+                member _.Key = uidKey kv.Key
+                member _.Count = kv.Value })
+        |> Seq.toArray
+
+    interface IEntryCacheDiagnostics with
+        member this.GetStats() = this.GetCacheStats()
+        member this.ResetStats() = this.ResetCacheStats()
+        member this.SetCacheBudget(bytes) = this.SetCacheBudget(bytes)
+        member this.SetTracingEnabled(enabled) = this.SetTracingEnabled(enabled)
+        member this.GetTopReads(n) = this.GetTopReadsList(n)
 
     // member this.LogCheckConsistency() =
     //     keyStorage.LogConsistencyCheck()

--- a/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
+++ b/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
@@ -48,13 +48,160 @@ export class KeyedStorageIndexedDB {
         this.batchOperations = [];
         this.batchSize = 25; // Optimal batch size for IndexedDB operations
 
-        // Cache management
+        // Cache management -- #542: byte-budgeted LRU (Map insertion-order-as-recency: a re-set
+        // via delete()+set() moves a key to the MRU end). 8 MB budget / 512 KB per-entry ceiling,
+        // same defaults as Layer 1 (KeyedStorageFileSystemAsync.fs), runtime-settable via
+        // `project fs-stats set kv <bytes>`.
         this.cacheEnabled = true;
         this.cache = new Map();
-        this.cacheLimit = 100;
+        this.cacheBudgetBytes = 8388608;
+        this.entryCeilingBytes = 524288;
+        this._cacheSizes = new Map();
+        this._cacheBytes = 0;
+
+        this.cacheHits = 0;
+        this.cacheMisses = 0;
+        this.cacheFlushes = 0;
+        this.cacheEvictions = 0;
+        this.admissionRefused = 0;
+        this.transactionsOpened = 0;
+        this.cacheHighWaterEntries = 0;
+        this.cacheHighWaterBytes = 0;
+        this.tracingEnabled = false;
+        this.topReads = new Map();
+
+        // #542: same-tick read coalescing -- see get()/_flushGetBatch(). Keyed to an ARRAY of
+        // waiters per key, not a single slot: two concurrent get() calls for the SAME key before
+        // the microtask flush must both resolve (a single-slot map would silently drop the first
+        // caller's resolver -- a hang, not an error; red-team finding, #542).
+        this._pendingGets = new Map();
+        this._getFlushScheduled = false;
 
         // Setup automatic cleanup handlers
         this._setupCleanupHandlers();
+    }
+
+    /**
+     * Approximate byte cost of a cached value, for the budget and high-water mark. #542
+     * @private
+     */
+    _sizeOf(value) {
+        if (value instanceof Uint8Array) return value.length;
+        if (typeof value === 'string') return value.length;
+        return 0;
+    }
+
+    /** @private */
+    _bumpHighWater() {
+        this.cacheHighWaterEntries = Math.max(this.cacheHighWaterEntries, this.cache.size);
+        this.cacheHighWaterBytes = Math.max(this.cacheHighWaterBytes, this._cacheBytes);
+    }
+
+    /** @private */
+    _bumpTopRead(key) {
+        const cur = this.topReads.get(key) || 0;
+        this.topReads.set(key, cur + 1);
+    }
+
+    /**
+     * Insert/replace in the cache under the byte budget + per-entry ceiling. An oversized entry
+     * is refused outright (never admitted), which is what excludes project.json-class entries
+     * without naming them and stops one large entry from evicting the rest of the working set. #542
+     * @private
+     */
+    _cacheSet(key, value) {
+        if (!this.cacheEnabled) return;
+        const size = this._sizeOf(value);
+        if (size > this.entryCeilingBytes) {
+            this.admissionRefused++;
+            this._cacheDelete(key); // no stale smaller copy left behind by a refused re-insert
+            return;
+        }
+        this._cacheDelete(key);
+        this.cache.set(key, value);
+        this._cacheSizes.set(key, size);
+        this._cacheBytes += size;
+        // Map iteration order == insertion order == LRU order; evict the oldest (index 0) one at
+        // a time. `> 1` is what makes "the cache never empties itself wholesale" structural: it
+        // always leaves at least the entry just inserted.
+        while (this._cacheBytes > this.cacheBudgetBytes && this.cache.size > 1) {
+            const oldestKey = this.cache.keys().next().value;
+            this._cacheBytes -= this._cacheSizes.get(oldestKey);
+            this.cache.delete(oldestKey);
+            this._cacheSizes.delete(oldestKey);
+            this.cacheEvictions++;
+        }
+        this._bumpHighWater();
+    }
+
+    /**
+     * Read + touch (moves the key to MRU via delete+set, since Map preserves insertion order).
+     * Does not bump hits/misses -- callers that care about read stats do that themselves, since
+     * "was this key ever cached" (e.g. exists()) and "read this key's content" (get()) are
+     * different questions. #542
+     * @private
+     */
+    _cacheGet(key) {
+        if (!this.cache.has(key)) return undefined;
+        const v = this.cache.get(key);
+        this.cache.delete(key);
+        this.cache.set(key, v);
+        return v;
+    }
+
+    /** Unconditional -- a caller-directed delete, never gated by the eviction guard in _cacheSet. @private */
+    _cacheDelete(key) {
+        if (this._cacheSizes.has(key)) {
+            this._cacheBytes -= this._cacheSizes.get(key);
+            this._cacheSizes.delete(key);
+        }
+        this.cache.delete(key);
+    }
+
+    /**
+     * Explicit wholesale clear -- the ONLY code path that empties the cache, used solely by
+     * close() (the session is genuinely ending). #542: the previous visibility-change forced
+     * flush is deleted outright, not replaced -- it discarded a read cache on a tab switch for no
+     * persistence benefit, and made cache behaviour (and any read-count measurement) depend on
+     * window focus.
+     * @private
+     */
+    _forceClearCache(reason) {
+        this.cacheFlushes++;
+        this.cache.clear();
+        this._cacheSizes.clear();
+        this._cacheBytes = 0;
+        clog("_forceClearCache", reason);
+    }
+
+    /** Zero the counters. Never touches cached entries -- see `project fs-stats reset`. #542 */
+    _resetStats() {
+        this.cacheHits = 0;
+        this.cacheMisses = 0;
+        this.cacheFlushes = 0;
+        this.cacheEvictions = 0;
+        this.admissionRefused = 0;
+        this.transactionsOpened = 0;
+        this.cacheHighWaterEntries = this.cache.size;
+        this.cacheHighWaterBytes = this._cacheBytes;
+    }
+
+    /** @private */
+    _getTopReads(n) {
+        const sorted = [...this.topReads.entries()].sort((a, b) => b[1] - a[1]);
+        return sorted.slice(0, Math.max(0, n)).map(([k, c]) => ({ Key: k, Count: c }));
+    }
+
+    /** @private */
+    _setCacheBudget(bytes) {
+        this.cacheBudgetBytes = bytes;
+        while (this._cacheBytes > this.cacheBudgetBytes && this.cache.size > 1) {
+            const oldestKey = this.cache.keys().next().value;
+            this._cacheBytes -= this._cacheSizes.get(oldestKey);
+            this.cache.delete(oldestKey);
+            this._cacheSizes.delete(oldestKey);
+            this.cacheEvictions++;
+        }
     }
 
     /**
@@ -70,11 +217,6 @@ export class KeyedStorageIndexedDB {
         };
 
         window.addEventListener('beforeunload', cleanupHandler);
-        window.addEventListener('visibilitychange', () => {
-            if (document.visibilityState === 'hidden') {
-                this._flushCacheIfNeeded(true);
-            }
-        });
     }
 
     /**
@@ -161,7 +303,7 @@ export class KeyedStorageIndexedDB {
 
         this.db = null;
         this.initPromise = null;
-        this.cache.clear();
+        this._forceClearCache('close');
     }
 
     /**
@@ -213,6 +355,7 @@ export class KeyedStorageIndexedDB {
         this.batchOperations = [];
 
         return new Promise((resolve, reject) => {
+            this.transactionsOpened++;
             const transaction = this.db.transaction([this.storeName], 'readwrite');
             const store = transaction.objectStore(this.storeName);
 
@@ -241,34 +384,15 @@ export class KeyedStorageIndexedDB {
                 clog("- ", op);
                 if (op.type === 'put') {
                     store.put(op.value, op.key);
-                    // Update cache
-                    if (this.cacheEnabled) {
-                        this.cache.set(op.key, op.value);
-                    }
+                    if (this.cacheEnabled) this._cacheSet(op.key, op.value);
                 } else if (op.type === 'delete') {
                     store.delete(op.key);
-                    // Remove from cache
-                    if (this.cacheEnabled) {
-                        this.cache.delete(op.key);
-                    }
+                    if (this.cacheEnabled) this._cacheDelete(op.key);
                 }
             });
-            clog("(batch flushed) ", operations.length)            
+            clog("(batch flushed) ", operations.length)
 
         });
-    }
-
-    /**
-     * Flush cache if it's getting too large
-     * @param {boolean} force - Whether to force flush regardless of size
-     * @private
-     */
-    _flushCacheIfNeeded(force = false) {
-        if (!this.cacheEnabled) return;
-
-        if (force || this.cache.size > this.cacheLimit) {
-            this.cache.clear();
-        }
     }
 
     /**
@@ -295,6 +419,7 @@ export class KeyedStorageIndexedDB {
      * @returns {Object} Object containing transaction, store and promise
      */
     createTransaction(mode) {
+        this.transactionsOpened++;
         const transaction = this.db.transaction([this.storeName], mode);
         const store = transaction.objectStore(this.storeName);
 
@@ -352,40 +477,78 @@ export class KeyedStorageIndexedDB {
     }
 
     /**
-     * Get a value by key with caching
+     * Get a value by key, with caching and same-tick read coalescing.
+     *
+     * #542: no longer opens its own transaction per call. A cache miss enqueues into
+     * `_pendingGets` and schedules exactly one `queueMicrotask` flush; the flush opens ONE
+     * readonly transaction and issues `store.get()` for every key queued since the last flush.
+     * This is independent of the existing write batch (beginBatch/commitBatch/_flushBatch),
+     * which stays write-only and unchanged -- reusing it for reads would deadlock: the F# call
+     * site (KeyedStorageFileSystemAsync.fs's getEntries) awaits Promise.all on the reads BEFORE
+     * calling commitBatch(), so a read that waited for an explicit commitBatch() to flush would
+     * never resolve. Self-flushing via microtask sidesteps that -- it needs no caller cooperation.
+     *
      * @param {string} key - The key to retrieve
      * @returns {Promise<any>} The value or null if not found
      */
     async get(key) {
         clog("get", key);
+        if (this.tracingEnabled) this._bumpTopRead(key);
 
-        // Check cache first if enabled
         if (this.cacheEnabled && this.cache.has(key)) {
-            return this.cache.get(key);
+            this.cacheHits++;
+            return this._cacheGet(key);
+        }
+        this.cacheMisses++;
+        return this._batchedGet(key);
+    }
+
+    /**
+     * Queue a cache-miss read for the next microtask's batched transaction. Waiters are stored
+     * as an ARRAY per key (not a single slot) so two concurrent get()s for the SAME key before
+     * the flush both resolve -- a single-slot map would silently drop the first caller's resolver
+     * (a hang, not an error; #542 red-team finding).
+     * @private
+     */
+    _batchedGet(key) {
+        if (!this._pendingGets.has(key)) this._pendingGets.set(key, []);
+        return new Promise((resolve, reject) => {
+            this._pendingGets.get(key).push({ resolve, reject });
+            if (!this._getFlushScheduled) {
+                this._getFlushScheduled = true;
+                queueMicrotask(() => this._flushGetBatch());
+            }
+        });
+    }
+
+    /** @private */
+    async _flushGetBatch() {
+        this._getFlushScheduled = false;
+        const pending = this._pendingGets;
+        this._pendingGets = new Map();
+        if (pending.size === 0) return;
+
+        try {
+            await this.ensureConnection();
+        } catch (err) {
+            for (const waiters of pending.values()) for (const { reject } of waiters) reject(err);
+            return;
         }
 
-        await this.ensureConnection();
-
         const { store, transactionPromise } = this.createTransaction('readonly');
-
-        return new Promise((resolve, reject) => {
+        for (const key of pending.keys()) {
             const request = store.get(key);
-
-            request.onerror = () => reject(request.error);
             request.onsuccess = () => {
                 const result = request.result === undefined ? null : request.result;
-
-                // Update cache
-                if (this.cacheEnabled && result !== null) {
-                    this.cache.set(key, result);
-                    this._flushCacheIfNeeded();
-                }
-
-                resolve(result);
+                if (this.cacheEnabled && result !== null) this._cacheSet(key, result);
+                for (const { resolve } of pending.get(key)) resolve(result);
             };
-
-            // Also wait for transaction to complete
-            transactionPromise.catch(reject);
+            request.onerror = () => {
+                for (const { reject } of pending.get(key)) reject(request.error);
+            };
+        }
+        transactionPromise.catch(err => {
+            for (const waiters of pending.values()) for (const { reject } of waiters) reject(err);
         });
     }
 
@@ -411,10 +574,7 @@ export class KeyedStorageIndexedDB {
         }
 
         // Update cache immediately for faster subsequent reads
-        if (this.cacheEnabled) {
-            this.cache.set(key, value);
-            this._flushCacheIfNeeded();
-        }
+        if (this.cacheEnabled) this._cacheSet(key, value);
 
         await this.ensureConnection();
 
@@ -438,11 +598,9 @@ export class KeyedStorageIndexedDB {
      */
     async remove(key) {
         clog("remove", key);
-        
+
         // Remove from cache immediately
-        if (this.cacheEnabled) {
-            this.cache.delete(key);
-        }
+        if (this.cacheEnabled) this._cacheDelete(key);
 
         // If in batch mode, add to batch operations
         if (this.batchMode) {
@@ -1410,6 +1568,29 @@ export function createKeyedStorageIndexedDB(rootKey) {
         CheckConsistency: () => db.checkConsistency(),
         FixDanglingReferences: () => db.fixDanglingReferences(),
         FixOrphanedEntries: () => db.fixOrphanedEntries(),
-        LogConsistencyCheck: () => db.logConsistencyCheck()
+        LogConsistencyCheck: () => db.logConsistencyCheck(),
+
+        // #542: cache diagnostics -- field names are PascalCase to match the F# LayerStats record
+        // that Get/SetStats unbox into (SutilOxide.FileSystem.LayerStats/ITopReadsEntry).
+        GetStats: () => ({
+            Hits: db.cacheHits,
+            Misses: db.cacheMisses,
+            Evictions: db.cacheEvictions,
+            Flushes: db.cacheFlushes,
+            AdmissionRefused: db.admissionRefused,
+            Entries: db.cache.size,
+            Bytes: db._cacheBytes,
+            HighWaterEntries: db.cacheHighWaterEntries,
+            HighWaterBytes: db.cacheHighWaterBytes,
+            BudgetBytes: db.cacheBudgetBytes || 0,
+            EntryCeilingBytes: db.entryCeilingBytes || 0,
+            Enabled: db.cacheEnabled,
+            TransactionsOpened: db.transactionsOpened,
+            ReadsIssued: db.cacheMisses,
+        }),
+        ResetStats: () => db._resetStats(),
+        SetCacheBudget: (bytes) => db._setCacheBudget(bytes),
+        SetTracingEnabled: (on) => { db.tracingEnabled = !!on; if (!on) db.topReads.clear(); },
+        GetTopReads: (n) => db._getTopReads(n),
     };
 }

--- a/src/SutilOxide/SutilOxide.fsproj
+++ b/src/SutilOxide/SutilOxide.fsproj
@@ -23,11 +23,13 @@
     <Compile Include="Modal.fs" />
     
     <Compile Include="FileSystem/FileSystem.fs" />
+    <Compile Include="FileSystem/EntryCache.fs" />
     <Compile Include="FileSystem/SubFolderFileSystem.fs" />
     <Compile Include="FileSystem/FileSystemExt.fs" />
     <Compile Include="FileSystem/CacheFileSystem.fs" />
     <Compile Include="FileSystem/KeyedStorageFileSystem.fs" />
     <Compile Include="FileSystem/KeyedStorageFileSystemAsync.fs" />
+    <Compile Include="FileSystem/EntryCacheDiagnostics.fs" />
     
     <Compile Include="CellEditor.fs" />
     <Compile Include="DomHelpers.fs" />


### PR DESCRIPTION
## Summary

Companion PR for [fsimgo#542](https://github.com/davedawkins/fsimgo/issues/542). Both storage-cache layers here evicted by clearing themselves wholesale once an entry-count limit was exceeded, instead of evicting the least-recently-used entry:

- **`KeyedStorageFileSystemAsync.fs`** (F# in-memory entry cache): `Dictionary<int, EntryStorage option>`, `CacheLimit = 100`, `trimCache()` called `entryCache.Clear()`.
- **`KeyedStorageIndexedDB.js`** (JS IndexedDB key/value cache): `Map`, `cacheLimit = 100`, `_flushCacheIfNeeded()` called `this.cache.clear()`. Also force-flushed on `visibilitychange` for no correctness reason, and opened one transaction per `get()` call.

A no-op recompile of an unchanged project re-read most of the working set from IndexedDB every time, because the cache had already wiped itself repeatedly during the walk that built it (23,441 reads on a 223-file project in the investigation behind fsimgo#542).

## Changes

- New `EntryCache.fs`: `LruByteCache<'v>` — byte-budgeted LRU keyed by `int`, with a per-entry size ceiling. Refuses (never admits) any entry above the ceiling — this is what excludes `project.json`-class oversized entries without naming them, and stops one large entry from evicting the rest of the working set. `Remove` is unconditional, never gated by the eviction guard, so deleting the last cached entry still works (a red-team finding on the plan: gating `Remove` the same way as the `Put`-triggered eviction loop would leave a deleted file served stale from cache).
- `KeyedStorageFileSystemAsync.fs` now uses `LruByteCache<EntryStorage option>` instead of the count-limited dictionary. No `Clear()` method exists anywhere on the production path — there is no code path left that can empty the cache wholesale.
- `KeyedStorageIndexedDB.js`: same byte-budget/ceiling policy via a `Map` (delete+set moves a key to MRU, since `Map` preserves insertion order). `close()` keeps an explicit wholesale clear (the session is genuinely ending); the `visibilitychange` forced flush is deleted outright — it discarded a read cache on a tab switch for no persistence benefit, and made cache behaviour (and any read-count measurement) depend on window focus.
- **Read batching**: `get()` no longer opens its own transaction per call. A cache miss enqueues into a same-tick pending-gets map and schedules exactly one `queueMicrotask` flush, which opens one `readonly` transaction and issues `store.get()` for every key queued since the last flush. This is independent of the existing write batch (`beginBatch`/`commitBatch`/`_flushBatch`), which stays write-only and unchanged — reusing it for reads would deadlock, since the F# call site (`KeyedStorageFileSystemAsync.fs`'s `getEntries`) awaits `Promise.all` on the reads *before* calling `commitBatch()`. The pending-gets map stores an **array** of waiters per key, not a single slot — a single-slot map would silently drop the first caller's resolver when two `get()` calls for the same key land before the flush (a hang, not an error), which is mainline on a cold compile (sibling files under one folder share an ancestor uid).
- Diagnostics: both layers gain always-on counters (hits/misses/evictions/flushes/admission-refused/entries/bytes/high-water) and a per-key top-reads histogram gated behind a `SetTracingEnabled` flag (unbounded, so it only accumulates while explicitly enabled). Surfaced through new `IKeyedStorageAsync` members (`GetStats`/`ResetStats`/`SetCacheBudget`/`SetTracingEnabled`/`GetTopReads`) and a small global `EntryCacheDiagnostics` registry for the Layer-1 side, consumed by fsimgo's `project fs-stats` command (see the fsimgo PR).
- Default budget: 8 MB per layer (comfortably covers a real project's source-file working set — measured ~416 KB for a 223-file project — with headroom for a session touching several projects). Default per-entry ceiling: 512 KB. Both are runtime-settable.

## Test plan

- [x] `client/tests/EntryCacheTests.fs` (in the consuming fsimgo repo, per that repo's existing convention for sutil-oxide unit tests — see `CachingFileSystemTests.fs`): LRU eviction order, per-entry ceiling refusal, never-empties-to-zero, `Remove` unconditional at count=1, hit/miss/eviction/admission-refused counters, `SetBudget` shrink-evicts, `ResetCounters` leaves entries untouched, high-water tracks peak not current.
- [x] `client/tests/EntryCacheRedFirstTests.fs`: red-first anchor — a 261-entry synthetic tree's second unchanged walk re-fetches ~691 entries against the pre-fix cache (verified failing before this change), ~0 after.
- [x] `client/src/ts/keyed-storage-cache.test.ts` (vitest + `fake-indexeddb`): mirrors the F# suite for the JS layer, plus the visibility-change regression test and two read-batching tests (N concurrent distinct-key `get()`s open exactly one transaction; two concurrent same-key `get()`s both resolve).
- [x] Full consuming-app verification (Fable compile, F# test suite, TS/vitest suite, E2E) run from the fsimgo side — see that PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>