### PR TITLE
fix: filter+debounce FileExplorer's refresh instead of refreshing on every fs event

### DIFF
--- a/src/SutilOxide/FileExplorer.fs
+++ b/src/SutilOxide/FileExplorer.fs
@@ -17,10 +17,61 @@ open Sutil.Styling
 
 open type Feliz.length
 open PromiseResult
+open SutilOxide.JsHelpers
 
 type UI =
     static member divc (cls:string) (items : seq<SutilElement>) =
         Html.div [ Attr.className cls ; yield! items ]
+
+let private norm (s : string) = s.Trim('/')
+
+/// True if a change at `path` could affect the listing shown for `cwd` -- i.e. `path`'s parent
+/// directory is `cwd`. Paths may arrive with a leading slash from a mounted
+/// SubFolderFileSystemAsync (#563); Cwd never does, so normalise both before comparing.
+let private cwdMatches (cwd : string) (path : string) =
+    norm (Path.getFolderName path) = norm cwd
+
+/// True if `path` IS `cwd`, or is an ancestor directory of it (including `cwd`'s immediate
+/// parent) -- e.g. the folder the user is browsing, or any directory above it, gets renamed or
+/// removed out from under them. `cwdMatches` alone never catches this: it compares against the
+/// *parent* of the changed entry, which only ever equals a direct child relationship, not an
+/// ancestor several levels up (#563 redteam finding; a rename cascades no descendant
+/// notification -- `KeyedStorageFileSystemAsync.renameFile` emits exactly one event for the
+/// renamed entry itself, unlike `removeDeep`, which does cascade -- so this has to be checked by
+/// path prefix, not by waiting for a per-descendant event). Segment-bounded (`npath + "/"`) so
+/// "docs" never falsely matches an unrelated "docsother".
+let private isCwdUnderPath (cwd : string) (path : string) =
+    let ncwd = norm cwd
+    let npath = norm path
+    ncwd = npath || npath = "" || ncwd.StartsWith(npath + "/")
+
+/// True if `cwd` is `path` itself or an ancestor of it -- the mirror check to `isCwdUnderPath`,
+/// needed for `Created`. `setFileContent`/`createFolderRecursive` auto-create every missing
+/// intermediate folder along a nested write with notification suppressed (`notify=false`); only
+/// the leaf entry's own event fires (#563 redteam finding, confirmed against
+/// KeyedStorageFileSystemAsync.fs). So writing "docs/newsub/readme.md" when "newsub" doesn't yet
+/// exist silently creates "newsub" as a new child of "docs" with no event of its own -- `cwd`
+/// must refresh on the leaf's Created event too, not just on a direct child. This can trigger one
+/// extra coalesced refresh for a write nested arbitrarily deep under an already-fully-existing
+/// subtree; the leading+trailing debounce still bounds the total dispatch count per burst, so
+/// that cost is acceptable against the alternative of a silently-stale listing.
+let private cwdIsAncestorOf (cwd : string) (path : string) =
+    let ncwd = norm cwd
+    let npath = norm path
+    ncwd = "" || npath = ncwd || npath.StartsWith(ncwd + "/")
+
+/// Whether a filesystem-change event can change a names-only listing rooted at `cwd`.
+/// `Updated` (content changed, name unchanged) never can -- the explorer only renders the
+/// Files/Folders name arrays (#563). If a future feature reads file content here (a size
+/// column, a preview), this becomes wrong -- update it then.
+let shouldRefreshListing (cwd : string) (ev : FileSystemEvent) : bool =
+    match ev.event with
+    | FileSystemEventType.Updated -> false
+    | FileSystemEventType.Created -> cwdIsAncestorOf cwd ev.path
+    | FileSystemEventType.Removed -> cwdMatches cwd ev.path || isCwdUnderPath cwd ev.path
+    | FileSystemEventType.Renamed newPath ->
+        cwdMatches cwd ev.path || cwdMatches cwd newPath
+        || isCwdUnderPath cwd ev.path || isCwdUnderPath cwd newPath
 
 type Msg =
     | DropFiles of FileList
@@ -301,6 +352,38 @@ let buttons m dispatch=
 
 let isRoot f = f = "/" || f = ""
 
+/// Leading-plus-trailing coalescing: the first qualifying call after a quiet period runs `f`
+/// immediately (so a single user action -- New File, Rename, Delete -- refreshes with no added
+/// latency, matching pre-#563 behaviour); further calls within `delayMs` are absorbed and, if any
+/// arrived, `f` runs once more when the burst goes quiet (so a bulk create/extract/checkout still
+/// converges on the final state instead of missing entries created after the leading refresh).
+/// Trailing-only would leave every single action (delayMs) slower than before #563 -- a redteam
+/// finding on this issue.
+let private leadingAndTrailing (schedule : TimeoutFn) (delayMs : int) (f : unit -> unit) : unit -> unit =
+    let mutable inCooldown = false
+    let mutable pendingTrailing = false
+    fun () ->
+        if inCooldown then
+            pendingTrailing <- true
+        else
+            inCooldown <- true
+            f()
+            schedule delayMs (fun () ->
+                inCooldown <- false
+                if pendingTrailing then
+                    pendingTrailing <- false
+                    f())
+
+/// Wires filesystem-change events to `dispatch FetchListing`, filtered by `shouldRefreshListing`
+/// and coalesced via `leadingAndTrailing` so a burst of relevant events (bulk create/extract/
+/// checkout) produces at most two refreshes -- immediate + one final -- instead of one per event,
+/// while a single event still refreshes immediately (#563).
+let wireFsEvents (schedule : TimeoutFn) (getCwd : unit -> string) (dispatch : Msg -> unit) : FileSystemEvent -> unit =
+    let refresh = leadingAndTrailing schedule 500 (fun () -> dispatch FetchListing)
+    fun ev ->
+        if shouldRefreshListing (getCwd()) ev then
+            refresh()
+
 let fileExplorer (classifier : string -> string) iconselector dispatch (m : Model) =
 
 
@@ -491,7 +574,7 @@ type FileExplorer( fs : IFsAsync ) =
         items |> Array.exists (fun f -> path = Path.combine (model.Value.Cwd) f)
 
     do
-        fs.OnChanged( fun _ -> dispatch FetchListing ) |> Promise.start
+        fs.OnChanged( wireFsEvents (createTimeout()) (fun () -> model.Value.Cwd) dispatch ) |> Promise.start
 
     with
         member _.View( classifier : string -> string, iconselector : string -> string ) = view classifier iconselector 


### PR DESCRIPTION
## Summary

`FileExplorer` refreshed its entire file listing and re-rendered on **every** filesystem-change event, including events where only file content changed. The explorer's model holds only file/folder names (`Files : string[]`, `Folders : string[]`) and nothing rendered depends on content, so `Updated` events never needed a refresh at all. Measured in the fsimgo app: ~64ms per `SetFileContent` call on an existing file, almost entirely DOM re-render cost against a 272-file / ~56k-node project. See fsimgo#563 for the full measurement and requirements.

- `shouldRefreshListing (cwd, ev)` decides whether a given filesystem event can change the listing shown for `cwd`:
  - `Updated` → never.
  - `Created` → when `cwd` is the created path itself or an ancestor of it. A nested write (`setFileContent`) auto-creates missing intermediate folders via `createFolderRecursive` with notification suppressed, so a brand-new folder can appear several levels under `cwd` with no event of its own at the direct-child level — this has to be an ancestor check, not a direct-parent check.
  - `Removed` / `Renamed` → when `cwd` (or, for rename, either endpoint) is the changed path itself or anywhere in its ancestor chain. `renameFile` emits exactly one event for the renamed entry; `removeDeep` cascades one event per descendant. Either way, a change to a directory the user is browsing — or to any directory above it — needs its own ancestor check, since neither code path guarantees an event whose *direct* parent is `cwd`.
- `wireFsEvents` wires the filter to `dispatch FetchListing` through `leadingAndTrailing`: the first qualifying event in a quiet period fires immediately (so the explorer's own New File / Rename / Delete actions keep their pre-fix responsiveness), and further qualifying events within a 500ms window coalesce into one trailing refresh (so a bulk create/extract/checkout still converges on the final listing, in at most two dispatches instead of one per event).

## Review process

Four `/redteam` passes iterated to convergence before landing (each found and fixed a real gap the previous pass's tests didn't catch):

1. The filter missed "the folder currently being browsed is itself renamed/removed" (a too-strict direct-parent-only check), and a pure trailing debounce added up to 500ms of latency to the explorer's own single actions, which pre-fix code never had.
2. The cwd-itself fix didn't generalize to "an ancestor of cwd (not cwd itself) is renamed/removed"; the 500ms debounce constant was asserted nowhere; every debounce test used a cwd that never changed mid-test, so a "read cwd once at construction instead of per event" bug would have stayed green.
3. `Created` only checked the event's direct parent, missing the auto-created-intermediate-folder case described above (confirmed by tracing `KeyedStorageFileSystemAsync.fs`'s actual `setFileContent`/`createFolderRecursive` notify-suppression).
4. Convergence check — traced whether `Renamed` needed the same ancestor-of-created-path treatment (`renameFile` requires the destination's parent to already exist, so it can't implicitly create folders the way `setFileContent` can — no gap), and root-path representation (`"/"` vs `""`) consistency across all three predicates (all route through the same `norm`, no asymmetry). No new defect found.

## Accepted residual risks (raised by redteam, not fixed in this PR)

- **Pre-existing, widened exposure window**: `update`'s `SetSelected` handler unconditionally clears `Renaming = false` regardless of whether the selection actually changed. This predates this fix, but the 500ms leading+trailing window is long enough that a user actively renaming a file is more likely to have that rename box closed out from under them by an unrelated but Cwd-matching refresh than under the old near-instant-refresh behavior. Fixing this is a separate, untested-here change to `SetSelected`'s semantics and is out of scope for this perf fix; flagging for its own issue.
- **No exception guard in `leadingAndTrailing`**: if `dispatch FetchListing` (via the injected `f`) threw synchronously, `inCooldown` would stay `true` with no timer ever scheduled to release it, silently killing further refreshes for the session. Traced the actual call chain (`getCwd` is a plain field read; `dispatch`'s `update` handler constructs a promise rather than executing inline) and found no currently-reachable path that triggers this. Noted as a structural fragility, not a demonstrated defect.

## Test plan

- [x] `client/tests/FileExplorerTests.fs` in the fsimgo repo (this library has no in-repo test project — tests for `SutilOxide.*` code live in fsimgo's `client/tests/`, referenced via the existing `SutilOxide.fsproj` ProjectReference, matching the established pattern for `EntryCacheTests.fs`/`EntryCacheRedFirstTests.fs`).
- [x] 30 tests: event-type × Cwd truth table, rename-across-boundary both directions, leading-slash path normalization, cwd-itself and ancestor-of-cwd renamed/removed, auto-created-intermediate-folder Created case, leading+trailing debounce coalescing (single action instant, 50-event burst → 1 immediate + 1 trailing, cooldown resets, delay value pinned at 500ms, cwd read fresh per event not captured once), and real-`KeyedStorageFileSystemAsync` regression tests (create/rename/delete sequence stays accurate; removing the browsed folder itself; auto-created nested folder).
- [x] Red-then-green verified: reverted the fix, confirmed the new test file fails to compile against unfixed source (the new functions don't exist yet), reapplied the fix, confirmed all tests pass.
- [x] Full fsimgo F# suite green: 779 passing (30 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)