### PR TITLE
perf: bulk write mode for the filesystem (fsimgo#569)

### DIFF
--- a/src/SutilOxide/FileSystem/EntryCache.fs
+++ b/src/SutilOxide/FileSystem/EntryCache.fs
@@ -104,6 +104,10 @@ type LruByteCache<'v>(sizeOf: 'v -> int, initialBudgetBytes: int, entryCeilingBy
     /// decision, so it must succeed even when this is the last cached entry (#542 red-team finding).
     member _.Remove(uid: int) = removeInternal uid
 
+    /// Drop every cached entry -- for when the backing store has discarded writes this cache recorded. fsimgo#569
+    member _.Clear() =
+        store.Clear(); sizes.Clear(); accessTick.Clear(); totalBytes <- 0
+
     member _.SetBudget(bytes: int) =
         budgetBytes <- bytes
         evictWhileOverBudget ()

--- a/src/SutilOxide/FileSystem/FileSystem.fs
+++ b/src/SutilOxide/FileSystem/FileSystem.fs
@@ -285,6 +285,10 @@ type IKeyedStorageAsync =
     abstract Remove: string -> Promise<unit>
     abstract BeginBatch: unit -> unit
     abstract CommitBatch: unit -> Promise<unit>
+    // fsimgo#569: bulk write -- inner BeginBatch/CommitBatch pairs become no-ops until CommitBulk/AbortBulk.
+    abstract BeginBulk: unit -> unit
+    abstract CommitBulk: unit -> Promise<unit>
+    abstract AbortBulk: unit -> unit
     abstract Close: unit -> Promise<unit>
     abstract CheckConsistency: unit -> Promise<obj>
     abstract LogConsistencyCheck: unit -> Promise<bool>
@@ -398,6 +402,11 @@ type IWriteOnlyFileSystemOf<'Unit> =
     abstract member RemoveEntry : path : string -> 'Unit
     abstract member RenameEntry : string * string -> 'Unit
 
+/// Write-side counterpart to IReadOnlyBatchingFileSystemOf. fsimgo#569
+type IWriteOnlyBatchingFileSystemOf<'Unit> =
+    inherit IWriteOnlyFileSystemOf<'Unit>
+    abstract member WriteEntries : (string * Content)[] -> 'Unit
+
 type IReadOnlyFileSystem = 
     inherit IReadOnlyFileSystemOf<SyncThrowable<Entry option>, SyncThrowable<Content option>, SyncThrowable<IDisposable>>
 
@@ -411,16 +420,23 @@ type IReadOnlyFileSystemAsync=
 type IReadOnlyBatchingFileSystemAsync= 
     inherit IReadOnlyBatchingFileSystemOf<Entry option, Content option, IDisposable>
 
-type IFileSystemAsync= 
-    inherit IWriteOnlyFileSystemOf<AsyncPromise<unit>>
+type IFileSystemAsync=
+    inherit IWriteOnlyBatchingFileSystemOf<AsyncPromise<unit>>
     inherit IReadOnlyBatchingFileSystemAsync
 
 type IFileSystemAsync with
-    member self.GetEntryBatchDefault (paths: string array): AsyncPromise<Entry option array> = 
+    member self.GetEntryBatchDefault (paths: string array): AsyncPromise<Entry option array> =
         paths |> Array.map self.GetEntry |> Promise.all
 
-    member self.GetContentBatchDefault (paths: string array): AsyncPromise<Content option array> = 
+    member self.GetContentBatchDefault (paths: string array): AsyncPromise<Content option array> =
         paths |> Array.map self.GetContent |> Promise.all
+
+    /// Sequential fallback for filesystems that cannot batch -- same order and failure point as a caller's own loop. fsimgo#569
+    member self.WriteEntriesDefault (entries: (string * Content)[]): AsyncPromise<unit> =
+        promise {
+            for (path, content) in entries do
+                do! self.WriteEntry(path, content)
+        }
 
 [<AutoOpen>]
 module FileSystemExt =

--- a/src/SutilOxide/FileSystem/KeyedStorageFileSystemAsync.fs
+++ b/src/SutilOxide/FileSystem/KeyedStorageFileSystemAsync.fs
@@ -815,7 +815,30 @@ with
                 else
                     mkResult "CreateFolder" <| fun () -> createFolder path true
 
-        member this.GetEntryBatch(path: string array): AsyncPromise<Entry option array> = 
+        // #569: takes the lock ONCE and drives the private per-entry path -- calling the interface
+        // WriteEntry here would re-enter mkResult's non-reentrant getLock and hang forever.
+        member this.WriteEntries(entries: (string * Content)[]): AsyncPromise<unit> =
+            mkResult "WriteEntries" <| fun () ->
+                promise {
+                    keyStorage.BeginBulk()
+                    try
+                        for (path, content) in entries do
+                            match content with
+                            | Content.Bytes data ->
+                                do! setFileContent(path, ByteBlob data)
+                            | Content.Entries empty ->
+                                if empty.Length <> 0 then
+                                    failwithf "Entries must be an empty array for folder creation: %s" path
+                                do! createFolder path true
+                        do! keyStorage.CommitBulk()
+                    with ex ->
+                        // Discard the chunk whole; the entry cache recorded writes that no longer exist.
+                        keyStorage.AbortBulk()
+                        entryCache.Clear()
+                        return raise ex
+                }
+
+        member this.GetEntryBatch(path: string array): AsyncPromise<Entry option array> =
             (fun _ -> path |> Array.map this.GetEntry |> Promise.all) |> mkResult "GetEntryBatch"
 
         member this.GetContentBatch(path: string array): AsyncPromise<Content option array> = 

--- a/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
+++ b/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
@@ -300,8 +300,14 @@ export class KeyedStorageIndexedDB {
         }
 
         if (this.db && !this.db.closed) {
-            // #569: await the flush -- fire-and-forget resumed after this.db was nulled and threw.
-            try { await this._flushBatch(true); } catch (_) { /* connection is going away regardless */ }
+            if (this.bulkDepth > 0) {
+                // #569: a bulk is all-or-nothing. Flushing half a chunk on unload can commit a
+                // parent entry whose child was never written -- a dangling reference on reload.
+                this._discardBulk();
+            } else {
+                // #569: await the flush -- fire-and-forget resumed after this.db was nulled and threw.
+                try { await this._flushBatch(true); } catch (_) { /* connection is going away regardless */ }
+            }
             if (this.db && !this.db.closed) this.db.close();
         }
 
@@ -360,9 +366,16 @@ export class KeyedStorageIndexedDB {
      */
     async commitBulk() {
         if (this.bulkDepth === 0) return;
-        this.bulkDepth--;
-        if (this.bulkDepth > 0) return;
-        await this._flushBatch(true);
+        if (this.bulkDepth > 1) { this.bulkDepth--; return; }
+        try {
+            await this._flushBatch(true);
+        } catch (err) {
+            // #569: clean up here. Decrementing the depth before the await would make the caller's
+            // AbortBulk a no-op, leaving discarded writes readable for the rest of the session.
+            this._discardBulk();
+            throw err;
+        }
+        this.bulkDepth = 0;
         this.batchMode = false;
     }
 
@@ -373,11 +386,20 @@ export class KeyedStorageIndexedDB {
         if (this.bulkDepth === 0) return;
         this.bulkDepth--;
         if (this.bulkDepth > 0) return;
+        this._discardBulk();
+    }
+
+    /**
+     * Drop any open bulk and everything it queued. Unconditional -- the queued writes never
+     * reached storage, so no cache may go on describing them. #569
+     * @private
+     */
+    _discardBulk() {
+        this.bulkDepth = 0;
+        this.batchMode = false;
         this.batchOperations = [];
-        // The queued writes are gone; neither cache may keep describing them.
         for (const key of this.batchPending.keys()) this._cacheDelete(key);
         this.batchPending.clear();
-        this.batchMode = false;
     }
 
     /**
@@ -405,6 +427,30 @@ export class KeyedStorageIndexedDB {
         const operations = [...byKey.values()];
         this.batchOperations = [];
 
+        // #569: retire a pending value only if it is still the one this flush wrote -- a put issued
+        // while the flush was in flight must survive it. On failure nothing landed, so the
+        // optimistic _cacheSet below must not survive either.
+        const retirePending = (landed) => {
+            for (const op of operations) {
+                const written = op.type === 'put' ? op.value : null;
+                if (this.batchPending.get(op.key) === written) this.batchPending.delete(op.key);
+                if (!landed) this._cacheDelete(op.key);
+            }
+        };
+
+        try {
+            return await this._runFlush(operations, retirePending);
+        } catch (err) {
+            // Covers the paths that never reach a transaction at all (connection refused, closing
+            // database): without this the queue is already empty and batchPending would go on
+            // serving writes that no transaction ever carried.
+            retirePending(false);
+            throw err;
+        }
+    }
+
+    /** @private */
+    async _runFlush(operations, retirePending) {
         await this.ensureConnection();
         if (!this.db || this.db.closed) throw new Error('Database closed before batch could be flushed');
 
@@ -416,17 +462,6 @@ export class KeyedStorageIndexedDB {
             // Add this transaction to pending set
             const transactionId = Date.now() + Math.random();
             this.pendingTransactions.add(transactionId);
-
-            // #569: retire a pending value only if it is still the one this transaction wrote --
-            // a put issued while the flush was in flight must survive it.
-            const retirePending = (landed) => {
-                for (const op of operations) {
-                    const written = op.type === 'put' ? op.value : null;
-                    if (this.batchPending.get(op.key) === written) this.batchPending.delete(op.key);
-                    // #569: nothing landed, so the optimistic _cacheSet below must not survive.
-                    if (!landed) this._cacheDelete(op.key);
-                }
-            };
 
             transaction.oncomplete = () => {
                 retirePending(true);

--- a/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
+++ b/src/SutilOxide/FileSystem/KeyedStorageIndexedDB.js
@@ -48,6 +48,11 @@ export class KeyedStorageIndexedDB {
         this.batchOperations = [];
         this.batchSize = 25; // Optimal batch size for IndexedDB operations
 
+        // #569: bulk write mode -- one owner (WriteEntries), inner beginBatch/commitBatch become no-ops.
+        this.bulkDepth = 0;
+        // #569: queued-but-unflushed values, so reads inside a long batch are not served stale. null = delete.
+        this.batchPending = new Map();
+
         // Cache management -- #542: byte-budgeted LRU (Map insertion-order-as-recency: a re-set
         // via delete()+set() moves a key to the MRU end). 8 MB budget / 512 KB per-entry ceiling,
         // same defaults as Layer 1 (KeyedStorageFileSystemAsync.fs), runtime-settable via
@@ -212,8 +217,7 @@ export class KeyedStorageIndexedDB {
     _setupCleanupHandlers() {
         // Close DB when page is unloaded to prevent resource leaks
         const cleanupHandler = () => {
-            this._flushBatch(true);
-            this.close();
+            this.close(); // #569: close() flushes; a second fire-and-forget flush only raced it
         };
 
         window.addEventListener('beforeunload', cleanupHandler);
@@ -289,21 +293,27 @@ export class KeyedStorageIndexedDB {
     /**
      * Close the database connection and clean up resources
      */
-    close() {
+    async close() {
         // Wait for any pending transactions to complete
         if (this.pendingTransactions.size > 0) {
             console.warn(`Closing database with ${this.pendingTransactions.size} pending transactions`);
         }
 
         if (this.db && !this.db.closed) {
-            // Flush any pending batch operations
-            this._flushBatch(true);
-            this.db.close();
+            // #569: await the flush -- fire-and-forget resumed after this.db was nulled and threw.
+            try { await this._flushBatch(true); } catch (_) { /* connection is going away regardless */ }
+            if (this.db && !this.db.closed) this.db.close();
         }
 
         this.db = null;
         this.initPromise = null;
         this._forceClearCache('close');
+
+        // #569: never leave a closed instance pinned in bulk mode -- reuse would queue forever.
+        this.bulkDepth = 0;
+        this.batchMode = false;
+        this.batchOperations = [];
+        this.batchPending.clear();
     }
 
     /**
@@ -311,6 +321,7 @@ export class KeyedStorageIndexedDB {
      * Operations will be queued and executed together
      */
     beginBatch() {
+        if (this.bulkDepth > 0) return; // #569: a bulk write owns the batch; nested pairs must not reset it
         if (!this.batchMode) {
             clog("beginBatch", "batchMode");
             this.batchMode = true;
@@ -324,10 +335,48 @@ export class KeyedStorageIndexedDB {
      */
     async commitBatch() {
         clog("commitBatch", this.batchMode);
+        if (this.bulkDepth > 0) return; // #569: only commitBulk closes a bulk write
         if (!this.batchMode) {
             return;
         }
         await this._flushBatch();
+        this.batchMode = false;
+    }
+
+    /**
+     * Begin a bulk write: many logical filesystem operations committed as one transaction. #569
+     */
+    beginBulk() {
+        this.bulkDepth++;
+        if (this.bulkDepth === 1 && !this.batchMode) {
+            this.batchMode = true;
+            this.batchOperations = [];
+        }
+    }
+
+    /**
+     * Commit a bulk write. Flush points are chosen by the caller, between whole entries. #569
+     * @returns {Promise<void>}
+     */
+    async commitBulk() {
+        if (this.bulkDepth === 0) return;
+        this.bulkDepth--;
+        if (this.bulkDepth > 0) return;
+        await this._flushBatch(true);
+        this.batchMode = false;
+    }
+
+    /**
+     * Discard a bulk write whole, so a failure cannot commit a half-written entry. #569
+     */
+    abortBulk() {
+        if (this.bulkDepth === 0) return;
+        this.bulkDepth--;
+        if (this.bulkDepth > 0) return;
+        this.batchOperations = [];
+        // The queued writes are gone; neither cache may keep describing them.
+        for (const key of this.batchPending.keys()) this._cacheDelete(key);
+        this.batchPending.clear();
         this.batchMode = false;
     }
 
@@ -349,10 +398,15 @@ export class KeyedStorageIndexedDB {
             return;
         }
 
-        await this.ensureConnection();
-
-        const operations = [...this.batchOperations];
+        // #569: snapshot BEFORE the await -- close() calls _flushBatch(true) without awaiting it.
+        // #569: last operation per key wins; createChildEntry re-queues the parent once per sibling.
+        const byKey = new Map();
+        for (const op of this.batchOperations) byKey.set(op.key, op);
+        const operations = [...byKey.values()];
         this.batchOperations = [];
+
+        await this.ensureConnection();
+        if (!this.db || this.db.closed) throw new Error('Database closed before batch could be flushed');
 
         return new Promise((resolve, reject) => {
             this.transactionsOpened++;
@@ -363,17 +417,31 @@ export class KeyedStorageIndexedDB {
             const transactionId = Date.now() + Math.random();
             this.pendingTransactions.add(transactionId);
 
+            // #569: retire a pending value only if it is still the one this transaction wrote --
+            // a put issued while the flush was in flight must survive it.
+            const retirePending = (landed) => {
+                for (const op of operations) {
+                    const written = op.type === 'put' ? op.value : null;
+                    if (this.batchPending.get(op.key) === written) this.batchPending.delete(op.key);
+                    // #569: nothing landed, so the optimistic _cacheSet below must not survive.
+                    if (!landed) this._cacheDelete(op.key);
+                }
+            };
+
             transaction.oncomplete = () => {
+                retirePending(true);
                 this.pendingTransactions.delete(transactionId);
                 resolve();
             };
 
             transaction.onerror = () => {
+                retirePending(false);
                 this.pendingTransactions.delete(transactionId);
                 reject(transaction.error);
             };
 
             transaction.onabort = () => {
+                retirePending(false);
                 this.pendingTransactions.delete(transactionId);
                 reject(new Error('Transaction was aborted'));
             };
@@ -456,6 +524,9 @@ export class KeyedStorageIndexedDB {
     async exists(key) {
         clog("exists", key);
 
+        // #569: a queued write (or delete tombstone) is newer than the cache or storage.
+        if (this.batchPending.has(key)) return this.batchPending.get(key) !== null;
+
         // Check cache first if enabled
         if (this.cacheEnabled && this.cache.has(key)) {
             return true;
@@ -494,6 +565,9 @@ export class KeyedStorageIndexedDB {
     async get(key) {
         clog("get", key);
         if (this.tracingEnabled) this._bumpTopRead(key);
+
+        // #569: a queued write is newer than anything in the cache or in storage.
+        if (this.batchPending.has(key)) return this.batchPending.get(key);
 
         if (this.cacheEnabled && this.cache.has(key)) {
             this.cacheHits++;
@@ -564,9 +638,11 @@ export class KeyedStorageIndexedDB {
         // If in batch mode, add to batch operations
         if (this.batchMode) {
             this.batchOperations.push({ type: 'put', key, value });
+            this.batchPending.set(key, value);
 
-            // Flush if we've hit batch size
-            if (this.batchOperations.length >= this.batchSize) {
+            // #569: during a bulk write the caller picks flush points between whole entries, so a
+            // size-triggered flush here would split one entry's writes across two transactions.
+            if (this.bulkDepth === 0 && this.batchOperations.length >= this.batchSize) {
                 await this._flushBatch();
             }
 
@@ -605,9 +681,9 @@ export class KeyedStorageIndexedDB {
         // If in batch mode, add to batch operations
         if (this.batchMode) {
             this.batchOperations.push({ type: 'delete', key });
+            this.batchPending.set(key, null); // #569: tombstone -- a read must not see the pre-batch value
 
-            // Flush if we've hit batch size
-            if (this.batchOperations.length >= this.batchSize) {
+            if (this.bulkDepth === 0 && this.batchOperations.length >= this.batchSize) {
                 await this._flushBatch();
             }
 
@@ -1561,6 +1637,9 @@ export function createKeyedStorageIndexedDB(rootKey) {
         // Additional methods that could be useful for optimizing the F# code
         BeginBatch: () => db.beginBatch(),
         CommitBatch: () => db.commitBatch(),
+        BeginBulk: () => db.beginBulk(),
+        CommitBulk: () => db.commitBulk(),
+        AbortBulk: () => db.abortBulk(),
         GetKeysWithPrefix: (prefix) => db.getKeysWithPrefix(prefix),
         Close: () => db.close(),
 

--- a/src/SutilOxide/FileSystem/SubFolderFileSystem.fs
+++ b/src/SutilOxide/FileSystem/SubFolderFileSystem.fs
@@ -24,6 +24,10 @@ type SubFolderFileSystemAsync( fs : IFsAsync, mountPoint : string) =
         member this.WriteEntry(path: string, content: Content): AsyncPromise<unit> =
             fs.WriteEntry(makePath path, content)
 
+        // fsimgo#569: forward, don't loop -- import into a sub-root must keep the underlying batching.
+        member this.WriteEntries(entries: (string * Content)[]): AsyncPromise<unit> =
+            fs.WriteEntries(entries |> Array.map (fun (path, content) -> makePath path, content))
+
         member this.RemoveEntry(path: string): AsyncPromise<unit> =
             fs.RemoveEntry(makePath path)
 


### PR DESCRIPTION
Filesystem side of [fsimgo#569](https://github.com/davedawkins/fsimgo/issues/569). fsimgo's zip
extractor wrote every entry in its own IndexedDB transaction — 6,714 transactions for a 5,400-file
project checkout, at ~0.48ms each. This adds the write-side batching the filesystem was missing.

## What this adds

**`WriteEntries : (string * Content)[] -> Promise<unit>`** on a new `IWriteOnlyBatchingFileSystemOf`,
mirroring the read side's `IReadOnlyBatchingFileSystemOf`. `IFileSystemAsync` inherits it; the sync
`IFileSystem` is untouched. F# cannot author default interface members, so the looping fallback takes
the same form the read side already uses — a `WriteEntriesDefault` extension member alongside
`GetEntryBatchDefault`.

**Bulk mode in `KeyedStorageIndexedDB`.** `beginBulk` / `commitBulk` / `abortBulk`, with exactly one
owner (`WriteEntries`, balanced by `try/finally`). While a bulk is open the existing internal
`beginBatch`/`commitBatch` pairs become no-ops.

## Why bulk mode rather than a depth counter

Depth-counting the existing `beginBatch`/`commitBatch` was the obvious approach and is wrong here:
every unbalanced call site corrupts the counter, and unbalanced call sites exist.
`createChildEntry`'s error path deliberately never commits, which would pin the depth above zero for
the rest of the session — writes silently stop reaching disk while reads keep working from the
Layer-1 cache, so the user loses everything on reload. Symmetrically, `notifyOnChange` sits inside
the `try` but *after* `commitBatch()` in `setFileContent`, `removeFile` and `renameFile`, so a single
throwing `OnChanged` subscriber commits twice and underflows. A separate single-owner flag has
neither failure mode.

## The other changes, each load-bearing for correctness rather than speed

- **`batchPending`** — queued writes are now visible to `get`/`exists`. `createChildEntry` re-reads
  the parent folder entry for every sibling it adds; once a batch spans hundreds of files and the
  entry cache evicts that parent (8 MB LRU, 512 KB per-entry ceiling), the read fell through to
  IndexedDB and returned a *stale* parent, silently dropping every child added since the batch
  opened. A pending value is retired only when the flush that wrote it completes *and* the pending
  value is still that one, so a write issued while a flush is in flight is not dropped.
- **Flush-time dedupe by key.** The parent entry is re-queued once per sibling, so a 500-file chunk
  queued ~500 copies of the same key — quadratic in folder width — plus one redundant `(root)` put
  per file. Last operation per key wins, which is identical semantics inside one transaction.
- **No size-triggered flush while bulk is open.** A single logical file write queues four puts
  (`(root)`, parent, child entry, content); a threshold firing between them commits a parent whose
  child never landed. Flush points are now chosen by the caller, between whole entries.
- **`_flushBatch` snapshots `batchOperations` before its `await`, and `close()` awaits its own
  flush.** `close()` nulls `this.db`, and the fire-and-forget flush then resumed against it and threw
  `TypeError: Cannot read properties of null`. Surfaced by the new `close()`-during-bulk test.
- **`LruByteCache.Clear()`** — so a discarded chunk does not leave the cache describing entries that
  were never written.

## Partial failure

`WriteEntries` discards the failing chunk whole (`abortBulk`) and purges both caches, then re-raises.
This is deliberately *better* than the previous behaviour, not the same: today a failure between
`createChildEntry`'s parent put and its child put commits a parent referencing a uid that was never
stored — a dangling reference the file explorer lists but cannot open.

## Notifications

Unchanged: one `Created`/`Updated` per entry, in order, because `WriteEntries` drives the same
per-entry path. This is load-bearing for fsimgo, whose caching filesystem uses `OnChanged` as its
only invalidation route for sub-mount writes.

## Tests

Tests live in the fsimgo repo (which already drives this class under `fake-indexeddb`) — see the
paired fsimgo PR. `keyed-storage-batch.test.ts` covers bulk lifetime, inner-pair no-op, read-through
of queued puts and delete tombstones, the write-during-flush race, dedupe, abort, and
close-during-bulk. Every mechanism above was verified red by mutation: removing the read-through,
the dedupe, or the inner-commit guard each turns a specific test red.
