### PR TITLE
VirtualFileSystem — mount several filesystems under one root

### DIFF
--- a/src/SutilOxide/FileSystem/SubFolderFileSystem.fs
+++ b/src/SutilOxide/FileSystem/SubFolderFileSystem.fs
@@ -61,3 +61,100 @@ module SubFolderFileSystemExt =
 
         member __.MakeRoot( path : string ) : IFsAsync =
             SubFolderFileSystemAsync( __, path ) :> IFsAsync
+            
+
+type VirtualFileSystem( mounts : (string * IFsAsync) [] ) =
+    let mountPoints = Map mounts
+
+    let getMountName (path : string) = 
+        path |> FileSystem.Internal.parsePath |> Array.tryHead 
+        
+    let getMountFs (path : string) = 
+        path |> FileSystem.Internal.parsePath |> Array.tryHead |> Option.bind (mountPoints.TryFind)
+        
+    let pathToInternal ( path :string ) = 
+        path |> FileSystem.Internal.parsePath |> Array.skip 1 |> String.concat "/"
+
+    let dispatch1 (path : string) (cmd : IFsAsync -> string -> AsyncPromise<'r>) =
+        match getMountFs path with
+        | Some fs -> cmd fs (pathToInternal path)
+        | None -> failwithf "Path not found: %s" path
+
+    let dispatch2 (path1 : string) (path2 : string) (cmd : IFsAsync -> string -> IFsAsync -> string -> AsyncPromise<'r>) =
+        match getMountFs path1, getMountFs path2 with
+        | Some fs1, Some fs2 -> cmd fs1 (pathToInternal path1) fs2 (pathToInternal path2)
+        | None, _ -> failwithf "Path not found: %s" path1
+        | _, None -> failwithf "Path not found: %s" path2
+
+    // carry the caller's index, not the path -- a batch may legitimately repeat a path
+    let batchFnOf (f) (fs : IFsAsync option) (indexedPaths : (int * string)[])   =
+        match fs with
+        | Some fs ->
+            f fs ( indexedPaths |> Array.map (snd >> pathToInternal) )
+            |> Promise.map (Array.mapi (fun i result -> fst indexedPaths[i], result))
+        | None ->
+            indexedPaths |> Array.map (fun (i,_) -> i, None) |> Promise.lift
+
+    let orderedBatch (paths : string array) (batchFn) =
+        paths
+        |> Array.mapi (fun i path -> i, path, (path |> getMountName |> Option.defaultValue ""))
+        |> Array.groupBy (fun (_,_,mount) -> mount)
+        |> Array.map (fun (mount, group) -> batchFn (getMountFs mount) (group |> Array.map (fun (i,path,_) -> i, path)))
+        |> Promise.all
+        |> Promise.map (Array.collect id >> Array.sortBy fst >> Array.map snd)
+
+    interface IFsAsync with
+        // IWriteOnlyFileSystemOf<AsyncPromise<unit>> members
+        member this.WriteEntry(path: string, content: Content): AsyncPromise<unit> =
+            dispatch1 path (fun fs path -> fs.WriteEntry(path, content))
+
+        // fsimgo#569: fan out per mount, one batched call each -- don't degrade to per-entry writes.
+        member this.WriteEntries(entries: (string * Content)[]): AsyncPromise<unit> =
+            entries
+            |> Array.groupBy (fun (path,_) -> path |> getMountName |> Option.defaultValue "")
+            |> Array.map (fun (mount, group) ->
+                match getMountFs mount with
+                | Some fs -> group |> Array.map (fun (path, content) -> pathToInternal path, content) |> fs.WriteEntries
+                | None -> failwithf "Path not found: %s" (fst group[0]))
+            |> Promise.all
+            |> Promise.map ignore
+
+        member this.RemoveEntry(path: string): AsyncPromise<unit> =
+            dispatch1 path (fun fs path -> fs.RemoveEntry(path))
+
+        // rename is only meaningful within one mount -- across mounts it is a copy-then-remove
+        member this.RenameEntry(src: string, tgt: string): AsyncPromise<unit> =
+            dispatch2 src tgt (fun fs1 src fs2 tgt ->
+                if System.Object.ReferenceEquals(fs1, fs2) then fs1.RenameEntry(src, tgt)
+                else failwithf "Cannot rename across filesystems: copy and then remove")
+
+        // IReadOnlyFileSystemOf members  
+        member this.GetEntry(path: string): AsyncPromise<Entry option> =
+            if path = "" || path = "/" then
+                { Name = ""; Meta = { EntryType = EntryType.Folder; CreatedAt = DateTime.MinValue; ModifiedAt = DateTime.MinValue; Size = 0} } |> Some |> Promise.lift
+            else
+                dispatch1 path (fun fs path -> fs.GetEntry(path))
+
+        member this.GetContent(path: string): AsyncPromise<Content option> =
+            if path = "" || path = "/" then
+                mounts |> Array.map (fun (name,fs) -> fs.GetEntry("/") |> Promise.map (Option.map (fun e -> { e with Name = name }))) |> Promise.all |> Promise.map (Array.choose id>>Entries>>Some)
+            else
+                dispatch1 path (fun fs path -> fs.GetContent(path))
+
+        member this.OnChanged(callback: FileSystemEvent -> unit): AsyncPromise<IDisposable> =
+            let fixevent (mount : string) (ev : FileSystemEvent) = 
+                ev.map (fun p1 -> Path.combine mount p1)
+
+            promise {
+                let! disposables = mounts |> Array.map (fun (mount, fs : IFsAsync) -> fs.OnChanged( fun ev -> callback( fixevent mount ev  ))) |> Promise.all
+                return { new IDisposable with member _.Dispose() = disposables |> Array.iter (fun d -> d.Dispose()) }
+            }
+        
+        // IReadOnlyBatchingFileSystemOf members
+        member this.GetEntryBatch(paths: string array): AsyncPromise<Entry option array> =
+            orderedBatch paths (batchFnOf (fun fs paths -> fs.GetEntryBatch(paths)))
+
+        member this.GetContentBatch(paths: string array): AsyncPromise<Content option array> =
+            orderedBatch paths (batchFnOf (fun fs paths -> fs.GetContentBatch(paths)))
+
+


### PR DESCRIPTION
Routes each path to the mount named by its first segment, so a caller can browse across projects through a single `IFsAsync`. Backs fsimgo's new `fs set models` shell command.

## What it does

- The root lists the mounts as folders; every other path dispatches to the mount its first segment names.
- Batch reads and `WriteEntries` fan out per mount and keep the underlying batching rather than degrading to per-entry calls.
- `OnChanged` subscribes to every mount and re-prefixes event paths with the mount name.

## Two things worth a look in review

**Batch ordering with duplicate paths.** `GetEntryBatch`/`GetContentBatch` promise results positionally aligned with the input array. Because this type fans out across mounts, results come back grouped per mount and have to be re-sorted into the caller's order. Keying that re-sort on a `Map<path, index>` collapses a repeated path onto one index, so both copies sort adjacent and displace whatever sat between them — a request for `["a"; "b"; "a"]` returns `[b; a; a]`, with the right length and no error, so the caller silently reads the wrong file's content. The re-sort now carries the caller's index through the fan-out instead.

No current caller passes duplicates — the ones in fsimgo build their path lists from directory and tree listings — so this is a latent contract bug rather than a live one. Fixed because a caller has no way to know duplicates are unsafe.

**Rename across mounts.** Dispatched within a mount; rejected across mounts, where it is a copy-then-remove rather than a rename. An earlier draft rejected it unconditionally, which broke `mv` and the file explorer's rename for every path once a virtual filesystem was active.

## Testing

`dotnet build src/SutilOxide/SutilOxide.fsproj` clean. Exercised through fsimgo's suites: 842 F# passing, 969 vitest passing.

No unit tests for `VirtualFileSystem` itself yet — the repo has an established filesystem-test pattern (`CachingFileSystemTests`, `WriteEntriesTests`) that path routing and batch ordering would fit, and the duplicate-path bug above is exactly the kind one test would have caught. Happy to add them here if you would rather not merge without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
