### PR TITLE
Normalise the JS argument at every observer-taking Subscribe

### DIFF
--- a/src/SutilOxide/Reactive.fs
+++ b/src/SutilOxide/Reactive.fs
@@ -28,6 +28,54 @@ type IAsyncEventSource<'T> =
     abstract Subscribe: ('T -> Promise<unit>) -> System.IDisposable
     abstract NotifyAsync: 'T -> Promise<unit>
 
+/// #782: Fable mangles the function-taking Subscribe, leaving the IObservable one as the only
+/// plain `Subscribe` a JS caller can reach. These normalise whatever JS actually passed.
+[<RequireQualifiedAccess>]
+module private Observer =
+    open Fable.Core.JsInterop
+
+    let private hasCallable (o: obj) (name: string) : bool =
+        emitJsExpr (o, name) "($0 != null && typeof $0[$1] === 'function')"
+
+    let private isFunction (o: obj) : bool = emitJsExpr o "(typeof $0 === 'function')"
+
+    /// Report and contain, matching fable-library's Observer: one bad subscriber must not abort
+    /// delivery to the rest of the notify loop, but it must not vanish either (#782).
+    let private report (context: string) (e: exn) =
+        Fable.Core.JS.console.error("SutilOxide " + context + ".Subscribe: subscriber threw", e)
+
+    /// Accept an observer, or wrap a bare callback, or fail here — never at the next Notify (#782).
+    let ofJs<'T> (context: string) (observer: IObserver<'T>) : IObserver<'T> =
+        // Observer first, so something callable that also carries OnNext keeps its observer behaviour.
+        if hasCallable observer "OnNext" then
+            if hasCallable observer "OnCompleted" && hasCallable observer "OnError" then
+                observer
+            else
+                // Fill what a hand-written JS observer omits, so trace's error path cannot TypeError (#782).
+                let hasCompleted = hasCallable observer "OnCompleted"
+                let hasError = hasCallable observer "OnError"
+                { new IObserver<'T> with
+                    member _.OnNext(v) = observer.OnNext v
+                    member _.OnCompleted() = if hasCompleted then observer.OnCompleted()
+                    member _.OnError(e) = if hasError then observer.OnError e else report context e }
+        elif isFunction observer then
+            let f : 'T -> unit = unbox observer
+            { new IObserver<'T> with
+                member _.OnNext(v) = f v
+                member _.OnCompleted() = ()
+                member _.OnError(e) = report context e }
+        else
+            failwithf "%s.Subscribe expects an observer with OnNext, or a callback function — received %s (#782)"
+                context (jsTypeof observer)
+
+    /// The async surface takes a callback, not an observer — fail at subscribe, not at NotifyAsync (#782).
+    let asCallback<'T,'R> (context: string) (handler: 'T -> 'R) : 'T -> 'R =
+        if isFunction handler then
+            handler
+        else
+            failwithf "%s.Subscribe expects a callback function — received %s (#782)"
+                context (jsTypeof handler)
+
 module Internal =
 
     open System.Collections.Generic
@@ -80,7 +128,8 @@ module Internal =
         inherit EventSourceWithResult<'T,unit>()
         
         interface IObservable<'T> with
-            member this.Subscribe (observer: IObserver<'T>): IDisposable = 
+            member this.Subscribe (observer: IObserver<'T>): IDisposable =
+                let observer = Observer.ofJs "EventSource" observer
                 this.Subscribe( fun v -> observer.OnNext(v) )
 
         interface IEventSource<'T> with
@@ -139,6 +188,7 @@ module Internal =
 
         interface System.IObservable<'T> with
             member _.Subscribe( observer : System.IObserver<'T> ) =
+                let observer = Observer.ofJs "Cell" observer
                 _init(false)
                 if _value_initialized then observer.OnNext(_value)
                 clients.Subscribe( fun v -> observer.OnNext(v) )
@@ -151,8 +201,8 @@ module Internal =
 
         interface IAsyncEventSource<'T> with
 
-            member __.Subscribe (arg: 'T -> Promise<unit>)= 
-                _es.Subscribe(arg)
+            member __.Subscribe (arg: 'T -> Promise<unit>)=
+                _es.Subscribe( Observer.asCallback "AsyncEventSource" arg )
 
             member this.NotifyAsync(value: 'T) : Promise<unit> =
                 let allPromises = _es.NotifyAndCollect(value)
@@ -212,6 +262,7 @@ module Signal =
             member _.Value = value
             member _.Dispose() = dispose0.Dispose()
             member _.Subscribe( h : IObserver<'T> ) =
+                let h = Observer.ofJs "Signal.fromObservable" h
                 let dispose = source.Subscribe( fun next ->
                     h.OnNext next
                 )
@@ -225,6 +276,7 @@ module Signal =
             member _.Value = value
             member _.Dispose() = ()
             member _.Subscribe( h : IObserver<'T> ) =
+                let h = Observer.ofJs "Signal.fromStore" h
                 let dispose = source.Subscribe( fun next ->
                     value <- next
                     h.OnNext next
@@ -287,10 +339,11 @@ module Signal =
         { new ISignal<'T> with 
             member __.Dispose() = src.Dispose()
             member __.Value with get() = src.Value
-            member __.Subscribe (observer: IObserver<'T>): IDisposable = 
+            member __.Subscribe (observer: IObserver<'T>): IDisposable =
+                let observer = Observer.ofJs "Signal.trace" observer
 
                 let clientId = nextId
-                nextId <- nextId
+                nextId <- nextId + 1   // drive-by: was `nextId <- nextId`, so every traced subscriber was id 0
 
                 let dispose = src.Subscribe(
                     { new IObserver<'T> with
@@ -319,13 +372,21 @@ module Signal =
 
 
 module Observable =
+    /// Give a plain Fable observable the same JS-argument normalisation as SutilOxide's own
+    /// surfaces — fable-library's combinators build observers with no guard of their own (#782).
+    let forJs<'T> (context: string) (src : System.IObservable<'T>) : System.IObservable<'T> =
+        { new System.IObservable<'T> with
+            member _.Subscribe( observer : IObserver<'T> ) =
+                src.Subscribe( Observer.ofJs context observer ) }
+
     let trace<'T> (log: Signal.TraceEvent<'T> -> unit) (src : System.IObservable<'T>) : IObservable<'T> =
         let mutable nextId = 0
-        { new IObservable<'T> with 
-            member __.Subscribe (observer: IObserver<'T>): IDisposable = 
+        { new IObservable<'T> with
+            member __.Subscribe (observer: IObserver<'T>): IDisposable =
+                let observer = Observer.ofJs "Observable.trace" observer
 
                 let clientId = nextId
-                nextId <- nextId
+                nextId <- nextId + 1   // drive-by: was `nextId <- nextId`, so every traced subscriber was id 0
 
                 let dispose = src.Subscribe(
                     { new IObserver<'T> with


### PR DESCRIPTION
## Normalise the JS argument at every observer-taking `Subscribe`

Fixes the trap reported as davedawkins/fsimgo#782.

### The problem

`[<Mangle>]` on `EventSourceWithResult` compiles the function-taking `Subscribe` to
`"SutilOxide.Reactive.Internal.EventSourceWithResult`2.SubscribeZ1FC644C9"`. The only member named
plain `Subscribe` on the emitted class is the `System.IObservable<'T>` implementation, which Fable
leaves unmangled because `IObservable` is a Base Class Library (BCL) interface. So a JS or TypeScript
caller writing the natural thing —

```js
project.FrameRenderer.Render.Subscribe(t => onFrame(t))
```

— stores a closure that dereferences `fn.OnNext`, and the dereference happens on the *next* `Notify`.
The throw is detached from the call site, and it takes down whatever loop was notifying. In fsimgo
that was the live frame ticker.

### The fix

The fix adds a private `module Observer` with two helpers, plus one public combinator.

`ofJs` checks for an observer **first**, so something callable that also carries `OnNext` keeps its
observer behaviour rather than being reduced to its call signature. It then:

- **normalises a partial observer.** `{ OnNext: fn }` — the natural hand-rolled JS shape — used to
  pass through untouched and then hit `trace`'s error path, throwing `observer.OnError is not a
  function`. That is the same misleading-TypeError class this issue exists to remove, so the missing
  members are filled in.
- **wraps a bare callback.**
- **fails at subscribe** for anything else, naming what it received. `undefined` (a typo'd or
  not-yet-assigned method reference) is the likeliest real form of this bug, and `typeof null` is
  `"object"` — a naive `typeof` chain lets both through to fail at the next notify.

`asCallback` covers the inverse trap on the async surface. `IAsyncEventSource.Subscribe` takes a
*callback* and carries no `[<Mangle>]`, so handing it an observer stored a non-callable and threw
`client is not a function` out of `NotifyAsync`. Auto-wrapping would be wrong there — it would
silently discard async ordering — so that site fails fast instead.

`Observable.forJs` gives the same normalisation to any plain `System.IObservable`. fable-library's
combinators (`Observable.choose`, `map`, …) build observers with no guard of their own, and fsimgo's
`IProject.onExecutionEvent` is exactly such a value — the one `IEvent` member its TS bridge declares,
and the one that surface model scripts actually reach.

The wrapper's `OnError` **reports and contains** rather than rethrowing. `Signal.trace` and
`Observable.trace` wrap delivery in `try ... with x -> observer.OnError(x)`; rethrowing from inside
that `with` aborted the notify loop, starving every sibling subscriber and skipping the
`NotifyCompleted` log. Containing matches fable-library's own `Observer`, whose `OnError` defaults to
a no-op — but it logs, so a throwing subscriber does not vanish.

Applied at these sites: `Internal.EventSource`, `Internal.Cell`, `Internal.PromiseEventSource`,
`Signal.fromObservable`, `Signal.fromStore`, `Signal.trace`, `Observable.trace`, plus the new
`Observable.forJs`.

### Why more than `EventSource`

The issue names `EventSource`, but `Cell` backs every `ISignal`/`ICell` crossing the same bridge —
`FrameRenderer.IsRunning` and `.Fps` sit on the same object as the `IEvent` that `Render` exposes.
Fixing one and not the other would leave the trap armed on the more widely used surface, and the
issue's own Impact section says every such surface carries it. Each additional site is one line.

The `PromiseEventSource` guard is the one change beyond the reported bug class. It backs
`IProject.onBeforeCompile`, two lines from `onBeforeSave : IObservable<unit>`, which takes the
opposite kind of argument. This can be dropped if the PR should stay scoped to the reported trap.

### Also here, disclosed rather than smuggled

`nextId <- nextId` at both trace sites was a typo for `nextId + 1`, so every traced subscriber was
`clientId 0` and the `Subscribed`/`NotifyStarted`/`NotifyCompleted` records could not be correlated.
It is unrelated to this issue, one line at each site, and directly adjacent to lines this change
already touches. Can be split into a separate commit if preferred.

### Verification

F# callers are unaffected, confirmed against real Fable 5.8 emit rather than assumed: F# object
expressions implementing `IObserver` compile to plain object literals, and F# code reaching the
function form goes through FSharp.Core's `IObservable.Subscribe(callback)` extension, which builds a
real `Observer` before it arrives here. `unbox<'T -> unit>` erases completely — `f v` becomes a
direct arity-1 call, so there is no currying hazard — and `SubscriberCount` (the #394 leak
instrumentation) is the client map's size, which the wrapper does not touch.

Tests live in fsimgo, which is where the Fable/Mocha harness is: 22 cases in
`client/tests/ReactiveJsSubscribeTests.fs`, reaching each member the way JS does via
`emitJsExpr (target, arg) "$0.Subscribe($1)"`. Naming `Subscribe` from F# binds a different overload
and proves nothing — an earlier draft of the test set made exactly that mistake.

Against this branch reverted, 16 of 21 then-existing tests failed; the ones that stayed green are the
intended non-regression cases. A mutation pass over the first draft of the suite found eleven of
twelve deliberately-wrong implementations surviving, which is why the tests now drive bad arguments,
context naming, and dispose hygiene across *every* guarded surface from a table rather than sampling
one. `dotnet build src/SutilOxide/SutilOxide.fsproj` is clean: 0 warnings, 0 errors.

### Pre-existing behaviour found and left alone

- `Signal.fromStore` delivers its initial value **twice** — Sutil stores replay on subscribe and
  `fromStore` then pushes `value` again. The test pins the exact sequence so the quirk stays visible.
- `Once`/`Until` on a `Cell` silently drop the current value: the JS-reachable `Cell.Subscribe`
  delivers before it registers, while the F# member registers first, so `Until`'s `sub` is still
  unassigned during the synchronous initial delivery and its body is skipped. Changing it would alter
  what every existing `Once` caller sees; left for you to decide rather than addressed in this PR.

<!-- reworded -->
