### PR TITLE
Port SutilKeyed and CellEditor to Sutil's comment-anchor binding model

### DIFF
--- a/src/SutilOxide/CellEditor.fs
+++ b/src/SutilOxide/CellEditor.fs
@@ -376,7 +376,7 @@ let findBest (allowed : string array) (value : string) =
 
 let bindFocus (isFocused : IObservable<bool>) : SutilElement =
     SutilElement.Define("bindFocus",fun ctx ->
-        let inputEl = ctx.Parent.AsDomNode :?> Browser.Types.HTMLInputElement
+        let inputEl = ctx.ParentNode :?> Browser.Types.HTMLInputElement
 
         let un = isFocused.Subscribe( fun f ->
             if f then

--- a/src/SutilOxide/Flow.fs
+++ b/src/SutilOxide/Flow.fs
@@ -38,8 +38,7 @@ module SutilKeyed =
         fun ctx ->
             let mutable keyMap : Map<'K,KeyedInfo<'T>> = Map.empty
             // Items build immediately before the anchor, which pins the block's position (fsimgo #896).
-            let anchor : Browser.Types.Node = upcast ctx.Document.createComment "keyedUnordered"
-            ctx.AddChild anchor
+            let anchor = bindingAnchor "keyedUnordered" ctx
 
             // Listen for changes to collection
             let unsub = items.Subscribe( fun newItems ->

--- a/src/SutilOxide/Flow.fs
+++ b/src/SutilOxide/Flow.fs
@@ -27,18 +27,19 @@ module SutilKeyed =
             v :?> 'T
 
     type KeyedInfo<'T> = {
-        Node : SutilEffect
+        // The item's stable top-level nodes; binding-rooted views keep their anchor here (fsimgo #896).
+        Nodes : Browser.Types.Node[]
         Value : IStore<'T>
     }
 
-    let keyedUnordered (items : System.IObservable<'T seq>) (view: IReadOnlyStore<'T> -> SutilElement) (key : 'T -> 'K) = 
+    let keyedUnordered (items : System.IObservable<'T seq>) (view: IReadOnlyStore<'T> -> SutilElement) (key : 'T -> 'K) =
         SutilElement.Define("keyedUnordered",
 
         fun ctx ->
             let mutable keyMap : Map<'K,KeyedInfo<'T>> = Map.empty
-            let group = SutilEffect.MakeGroup("keyed",ctx.Parent,ctx.Previous)
-            let keyedNode = Group group
-            let keyedCtx = ctx |> ContextHelpers.withParent keyedNode
+            // Items build immediately before the anchor, which pins the block's position (fsimgo #896).
+            let anchor : Browser.Types.Node = upcast ctx.Document.createComment "keyedUnordered"
+            ctx.AddChild anchor
 
             // Listen for changes to collection
             let unsub = items.Subscribe( fun newItems ->
@@ -53,10 +54,10 @@ module SutilKeyed =
                         match keyMap.TryFind k with
                         | None ->
                             let store = Store.make item
-                            let sutilNode = keyedCtx |> build (view store)
+                            let nodes = (ctx |> ContextHelpers.withAnchor anchor) |> build (view store)
                             {
-                                Node = sutilNode
-                                Value =store
+                                Nodes = nodes
+                                Value = store
                             }
                         | Some r ->
                             item |> Store.set r.Value
@@ -65,17 +66,20 @@ module SutilKeyed =
                     newKeyMap <- newKeyMap.Add(k, itemRec) )
 
                 // Remove missing items from document
-                keyMap |> Seq.iter( fun kv ->if not (newKeyMap.ContainsKey kv.Key) then kv.Value.Node.Dispose())
+                keyMap |> Seq.iter( fun kv ->
+                    if not (newKeyMap.ContainsKey kv.Key) then
+                        kv.Value.Nodes |> Array.iter Sutil.DomHelpers.removeNode )
 
                 // Update current items
                 keyMap <- newKeyMap
+                Sutil.DomHelpers.setBindNodes anchor (keyMap |> Seq.collect (fun kv -> kv.Value.Nodes) |> Array.ofSeq)
             )
 
-            group.RegisterUnsubscribe ( fun () -> 
+            SutilEffect.RegisterUnsubscribe ( anchor, fun () ->
                 unsub.Dispose()
             )
 
-            keyedNode
+            [| anchor |]
         )
     
 [<AutoOpen>]


### PR DESCRIPTION
## Port to Sutil's comment-anchor binding model (fsimgo davedawkins/fsimgo#896)

Sutil's companion PR deletes `SutilGroup` and the `SutilEffect` DU in favour of comment-node anchors and `Node[]` build results. This PR ports the two places sutil-oxide touched that machinery:

- `SutilKeyed.keyedUnordered` in `Flow.fs` anchors its block with `Core.bindingAnchor`, holds each item's top-level nodes as a plain array, removes missing items with `DomHelpers.removeNode`, and records its live nodes on the anchor for outer-binding disposal.
- `CellEditor.fs` reads `ctx.ParentNode` now that `BuildContext.Parent` is a `Node`.

Merge back-to-back with the Sutil PR: fsimgo builds both libraries from fresh clones of `main`, so the pair must cross together. Verified against fsimgo: full `dotnet build fsimgo.sln` green, F# Mocha 1964/1964, graph editor / node view / page E2E specs 16/16.

The sample app's `App.fs`/`TextEditor.fs` fail `dotnet build` with strict-indentation errors on `main` already; this PR does not touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CLwVoFQe73qc93XQ71H8G

<!-- reworded -->
